### PR TITLE
Update Init() interface to accept the mapping of name -> selector

### DIFF
--- a/dataprocessors/csv/csv.go
+++ b/dataprocessors/csv/csv.go
@@ -41,7 +41,7 @@ func NewCsvProcessor() *CsvProcessor {
 	return &CsvProcessor{}
 }
 
-func (p *CsvProcessor) Init(params map[string]string) error {
+func (p *CsvProcessor) Init(params map[string]string, measurements map[string]string, categories map[string]string) error {
 	if format, ok := params["time_format"]; ok {
 		p.timeFormat = format
 	}

--- a/dataprocessors/csv/csv_test.go
+++ b/dataprocessors/csv/csv_test.go
@@ -122,7 +122,7 @@ func testInitFunc() func(*testing.T) {
 	params := map[string]string{}
 
 	return func(t *testing.T) {
-		err := p.Init(params)
+		err := p.Init(params, nil, nil)
 		assert.NoError(t, err)
 	}
 }
@@ -135,7 +135,7 @@ func testGetObservationsFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewCsvProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -205,7 +205,7 @@ func testGetObservationsCustomTimeFunc() func(*testing.T) {
 		dp := NewCsvProcessor()
 		err = dp.Init(map[string]string{
 			"time_format": "2006-01-02 15:04:05-07:00",
-		})
+		}, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(localData)
@@ -237,7 +237,7 @@ func testGetObservationsTwiceFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewCsvProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -272,7 +272,7 @@ func testGetObservationsSameDataFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewCsvProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -317,7 +317,7 @@ func testGetStateFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewCsvProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -362,7 +362,7 @@ func testGetStateTagsFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewCsvProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -415,7 +415,7 @@ func testGetStateTwiceFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewCsvProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -479,7 +479,7 @@ func testgetColumnMappingsFunc() func(*testing.T) {
 func benchGetObservationsFunc(c *file.FileConnector) func(*testing.B) {
 	return func(b *testing.B) {
 		dp := NewCsvProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		if err != nil {
 			b.Error(err)
 		}

--- a/dataprocessors/dataprocessor.go
+++ b/dataprocessors/dataprocessor.go
@@ -11,7 +11,7 @@ import (
 )
 
 type DataProcessor interface {
-	Init(params map[string]string) error
+	Init(params map[string]string, measurements map[string]string, categories map[string]string) error
 	OnData(data []byte) ([]byte, error)
 	GetObservations() ([]observations.Observation, error)
 	GetState(fields []string) ([]*state.State, error)

--- a/dataprocessors/flux/fluxcsv.go
+++ b/dataprocessors/flux/fluxcsv.go
@@ -36,7 +36,7 @@ func NewFluxCsvProcessor() *FluxCsvProcessor {
 	return &FluxCsvProcessor{}
 }
 
-func (p *FluxCsvProcessor) Init(params map[string]string) error {
+func (p *FluxCsvProcessor) Init(params map[string]string, measurements map[string]string, categories map[string]string) error {
 	return nil
 }
 

--- a/dataprocessors/flux/fluxcsv_test.go
+++ b/dataprocessors/flux/fluxcsv_test.go
@@ -28,7 +28,7 @@ func testInitFunc() func(*testing.T) {
 	params := map[string]string{}
 
 	return func(t *testing.T) {
-		err := p.Init(params)
+		err := p.Init(params, nil, nil)
 		assert.NoError(t, err)
 	}
 }
@@ -43,7 +43,7 @@ func testGetObservationsFunc(data []byte) func(*testing.T) {
 		dp := NewFluxCsvProcessor()
 		err := dp.Init(map[string]string{
 			"field": "_value",
-		})
+		}, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -97,7 +97,7 @@ func testGetObservationsTwiceFunc(data []byte) func(*testing.T) {
 		dp := NewFluxCsvProcessor()
 		err := dp.Init(map[string]string{
 			"field": "_value",
-		})
+		}, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -133,7 +133,7 @@ func testGetObservationsSameDataFunc(data []byte) func(*testing.T) {
 		dp := NewFluxCsvProcessor()
 		err := dp.Init(map[string]string{
 			"field": "_value",
-		})
+		}, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)

--- a/dataprocessors/json/json.go
+++ b/dataprocessors/json/json.go
@@ -44,7 +44,7 @@ func NewJsonProcessor() *JsonProcessor {
 	return &JsonProcessor{}
 }
 
-func (p *JsonProcessor) Init(params map[string]string) error {
+func (p *JsonProcessor) Init(params map[string]string, measurements map[string]string, categories map[string]string) error {
 	// Default format if not specified in params
 	format := "default"
 

--- a/dataprocessors/json/json_test.go
+++ b/dataprocessors/json/json_test.go
@@ -61,7 +61,7 @@ func testInitFunc() func(*testing.T) {
 	params := map[string]string{}
 
 	return func(t *testing.T) {
-		err := p.Init(params)
+		err := p.Init(params, nil, nil)
 		assert.NoError(t, err)
 	}
 }
@@ -74,7 +74,7 @@ func testInvalidInitFunc() func(*testing.T) {
 	params["format"] = "nonexist"
 
 	return func(t *testing.T) {
-		err := p.Init(params)
+		err := p.Init(params, nil, nil)
 		assert.Error(t, err)
 		assert.Equal(t, "unable to find json format 'nonexist'", err.Error())
 	}
@@ -88,7 +88,7 @@ func testGetObservationsFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewJsonProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -125,7 +125,7 @@ func testGetObservationsInvalidStringFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewJsonProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -157,7 +157,7 @@ func testGetObservationsTwiceFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewJsonProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -193,7 +193,7 @@ func testGetObservationsSameDataFunc(data []byte) func(*testing.T) {
 		}
 
 		dp := NewJsonProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)
@@ -249,7 +249,7 @@ func testOnDataInvalidSchema(data []byte, validationError string) func(*testing.
 		}
 
 		dp := NewJsonProcessor()
-		err := dp.Init(nil)
+		err := dp.Init(nil, nil, nil)
 		assert.NoError(t, err)
 
 		_, err = dp.OnData(data)


### PR DESCRIPTION
As part of enabling categorical data, we need to differentiate whether data is a measurement of a category in the data source. This change updates the interface to allow the runtime to send the mapping from the manifest file.