### PR TITLE
Switch to sending `measurements` instead of `data` for GetObservations()

### DIFF
--- a/dataprocessors/csv/csv.go
+++ b/dataprocessors/csv/csv.go
@@ -11,15 +11,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/spiceai/spiceai/pkg/loggers"
 	"github.com/spiceai/spiceai/pkg/observations"
 	"github.com/spiceai/spiceai/pkg/time"
 	"github.com/spiceai/spiceai/pkg/util"
-	"go.uber.org/zap"
-)
-
-var (
-	zaplog *zap.Logger = loggers.ZapLogger()
 )
 
 const (
@@ -164,7 +158,7 @@ func (p *CsvProcessor) getObservations(reader io.Reader) ([]observations.Observa
 		}
 
 		if len(measurements) > 0 {
-			observation.Data = measurements
+			observation.Measurements = measurements
 		}
 
 		if len(categories) > 0 {
@@ -199,26 +193,6 @@ func getCsvHeaderAndLines(input io.Reader) ([]string, [][]string, error) {
 	}
 
 	return headers, lines, nil
-}
-
-// Returns mapping of column index to path and field name
-func getColumnMappings(headers []string) ([]string, []string, error) {
-	numDataFields := len(headers) - 1
-
-	columnToPath := make([]string, numDataFields)
-	columnToFieldName := make([]string, numDataFields)
-
-	for i := 1; i < len(headers); i++ {
-		header := headers[i]
-		dotIndex := strings.LastIndex(header, ".")
-		if dotIndex == -1 {
-			return nil, nil, fmt.Errorf("header '%s' expected to be full-qualified", header)
-		}
-		columnToPath[i-1] = header[:dotIndex]
-		columnToFieldName[i-1] = header[dotIndex+1:]
-	}
-
-	return columnToPath, columnToFieldName, nil
 }
 
 func getFieldMappings(fields map[string]string, headers map[string]int) map[string]int {

--- a/dataprocessors/csv/csv_test.go
+++ b/dataprocessors/csv/csv_test.go
@@ -159,7 +159,7 @@ func testGetObservationsFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1605312000,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"open":   16339.56,
 				"high":   16339.6,
 				"low":    16240,
@@ -235,7 +235,7 @@ func testGetObservationsCustomTimeFunc() func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1547575074,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"val": 34,
 			},
 		}
@@ -274,7 +274,7 @@ func testGetObservationsTwiceFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1605312000,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"open":   16339.56,
 				"high":   16339.6,
 				"low":    16240,
@@ -319,7 +319,7 @@ func testGetObservationsSameDataFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1605312000,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"open":   16339.56,
 				"high":   16339.6,
 				"low":    16240,

--- a/dataprocessors/flux/fluxcsv.go
+++ b/dataprocessors/flux/fluxcsv.go
@@ -155,9 +155,9 @@ func (p *FluxCsvProcessor) GetObservations() ([]observations.Observation, error)
 						}
 
 						observation := observations.Observation{
-							Time: times.Value(i) / int64(time.Second),
-							Data: rowData,
-							Tags: tagData,
+							Time:         times.Value(i) / int64(time.Second),
+							Measurements: rowData,
+							Tags:         tagData,
 						}
 
 						tableObservations[i] = observation

--- a/dataprocessors/flux/fluxcsv_test.go
+++ b/dataprocessors/flux/fluxcsv_test.go
@@ -57,13 +57,13 @@ func testGetObservationsFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1629159360,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"usage_idle": 99.56272495215877,
 			},
 			Tags: []string{"cpu-total", "DESKTOP-2BSF9I6"},
 		}
 		assert.Equal(t, expectedFirstObservation.Time, actualObservations[0].Time, "First Observation not correct")
-		assert.Equal(t, expectedFirstObservation.Data, actualObservations[0].Data, "First Observation not correct")
+		assert.Equal(t, expectedFirstObservation.Measurements, actualObservations[0].Measurements, "First Observation not correct")
 		assert.ElementsMatch(t, expectedFirstObservation.Tags, actualObservations[0].Tags, "First Observation not correct")
 
 		expectedObservationsBytes, err := os.ReadFile("../../test/assets/data/json/TestFlux-GetObservations()-expected_observations.json")
@@ -81,7 +81,7 @@ func testGetObservationsFunc(data []byte) func(*testing.T) {
 
 		for idx, expectedObservation := range expectedObservations {
 			assert.Equal(t, expectedObservation.Time, actualObservations[idx].Time)
-			assert.Equal(t, expectedObservation.Data, actualObservations[idx].Data)
+			assert.Equal(t, expectedObservation.Measurements, actualObservations[idx].Measurements)
 			assert.ElementsMatch(t, expectedObservation.Tags, actualObservations[idx].Tags)
 		}
 	}
@@ -108,13 +108,13 @@ func testGetObservationsTwiceFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1629159360,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"usage_idle": 99.56272495215877,
 			},
 			Tags: []string{"cpu-total", "DESKTOP-2BSF9I6"},
 		}
 		assert.Equal(t, expectedFirstObservation.Time, actualObservations[0].Time, "First Observation not correct")
-		assert.Equal(t, expectedFirstObservation.Data, actualObservations[0].Data, "First Observation not correct")
+		assert.Equal(t, expectedFirstObservation.Measurements, actualObservations[0].Measurements, "First Observation not correct")
 		assert.ElementsMatch(t, expectedFirstObservation.Tags, actualObservations[0].Tags, "First Observation not correct")
 
 		actualObservations2, err := dp.GetObservations()
@@ -144,13 +144,13 @@ func testGetObservationsSameDataFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1629159360,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"usage_idle": 99.56272495215877,
 			},
 			Tags: []string{"cpu-total", "DESKTOP-2BSF9I6"},
 		}
 		assert.Equal(t, expectedFirstObservation.Time, actualObservations[0].Time, "First Observation not correct")
-		assert.Equal(t, expectedFirstObservation.Data, actualObservations[0].Data, "First Observation not correct")
+		assert.Equal(t, expectedFirstObservation.Measurements, actualObservations[0].Measurements, "First Observation not correct")
 		assert.ElementsMatch(t, expectedFirstObservation.Tags, actualObservations[0].Tags, "First Observation not correct")
 
 		_, err = dp.OnData(data)

--- a/dataprocessors/json/json.go
+++ b/dataprocessors/json/json.go
@@ -136,7 +136,7 @@ func (p *JsonProcessor) GetObservations() ([]observations.Observation, error) {
 		}
 
 		if len(measurements) > 0 {
-			observation.Data = measurements
+			observation.Measurements = measurements
 		}
 
 		if len(categories) > 0 {

--- a/dataprocessors/json/json_test.go
+++ b/dataprocessors/json/json_test.go
@@ -81,7 +81,7 @@ func testGetObservationsFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1605312000,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"eventId": 806.42,
 				"height":  29,
 				"rating":  86,
@@ -124,7 +124,7 @@ func testGetObservationsSelectedMeasurementsFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1605312000,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"eventId": 806.42,
 				"rating":  86,
 				"target":  42,
@@ -204,7 +204,7 @@ func testGetObservationsTwiceFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1605312000,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"eventId": 806.42,
 				"height":  29,
 				"rating":  86,
@@ -248,7 +248,7 @@ func testGetObservationsSameDataFunc(data []byte) func(*testing.T) {
 
 		expectedFirstObservation := observations.Observation{
 			Time: 1605312000,
-			Data: map[string]float64{
+			Measurements: map[string]float64{
 				"eventId": 806.42,
 				"height":  29,
 				"rating":  86,

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/influxdata/influxdb-client-go v1.4.0
 	github.com/jonboulle/clockwork v0.2.2
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/spiceai/spiceai v0.2.1-alpha-rc-spiced.0.20211014094531-e5a53f0c5fe0
+	github.com/spiceai/spiceai v0.2.1-alpha-rc-spiced.0.20211015023415-6b33504a8a88
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1013,6 +1013,8 @@ github.com/spiceai/spiceai v0.2.0-alpha-rc-spiced.0.20210924080330-e4e6de522889/
 github.com/spiceai/spiceai v0.2.0-alpha-rc-spiced.0.20210928064733-8a93c58a76a3/go.mod h1:tgcoJEmidasLl0S4zOK0AGS4HsYiyHYkG0XrV5pjFNI=
 github.com/spiceai/spiceai v0.2.1-alpha-rc-spiced.0.20211014094531-e5a53f0c5fe0 h1:wkk7oX37GnAmsmqX8abTrjHX+cDBgI+WWiiQjEBAiDQ=
 github.com/spiceai/spiceai v0.2.1-alpha-rc-spiced.0.20211014094531-e5a53f0c5fe0/go.mod h1:3mDEuZlow9h0mMLhbyZB5CTbOahITrBc30cRADE5AlY=
+github.com/spiceai/spiceai v0.2.1-alpha-rc-spiced.0.20211015023415-6b33504a8a88 h1:6k/3WwPNbD7AyPcpYquE/GtDBiee431xDI697aosRNc=
+github.com/spiceai/spiceai v0.2.1-alpha-rc-spiced.0.20211015023415-6b33504a8a88/go.mod h1:3mDEuZlow9h0mMLhbyZB5CTbOahITrBc30cRADE5AlY=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/test/assets/data/json/TestFlux-GetObservations()-expected_observations.json
+++ b/test/assets/data/json/TestFlux-GetObservations()-expected_observations.json
@@ -1,24302 +1,17012 @@
 [
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56272495215877
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56016726103087
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5835393622478
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58402078629656
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5845216501822
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57623697230123
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55437672689656
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5580663115556
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57047717487701
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56588223401677
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57103261436396
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51912011273106
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55234213746569
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55180199822242
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56428245570355
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56380120172008
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57163114674688
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57628990258642
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55400459643977
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56954922643911
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56639528920515
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58501791005317
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55596161595464
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57048945192894
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56275618296179
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54767641738
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53715707724253
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5435510231879
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57049880764062
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56006262514232
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56428472279758
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54340188579111
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56163942041026
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54243082423308
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53260747139016
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54190472995994
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53931142563523
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54659939004848
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54554796120284
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54815374439725
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54918058401198
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5174184908498
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52583424394392
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55018640641283
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54186776303249
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55121453412518
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55589968306454
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5288476001143
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52878838709167
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54394932912923
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5237632592217
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54394744956545
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53251304516625
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54245924010785
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56314451723289
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52165820417606
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53658778096944
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54398622675542
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53667778911421
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57200611001228
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55126420913825
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52166358251328
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54088251654694
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52731309634208
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55902096521059
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55954277895158
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54134808403433
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55696250152289
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54464017527937
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55903717360074
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53307987284104
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49046772476562
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52738082703941
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5569013996399
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54030691935368
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54344797526026
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55279701466911
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55072376321056
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52048388897504
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55069985627449
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54394153228253
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51078097801786
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53979957775033
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56675835568541
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5356491581282
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53308356951963
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47307131100295
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41662187490589
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42942086131892
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4326553386967
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43379176718891
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4909254526525
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52984262283105
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48398438386111
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49402820826414
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51530485481273
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4833604442269
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4976328839363
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53124754859117
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4935106335961
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50377241430054
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49192125468488
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49713462266986
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5343547669067
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48052076336835
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50687519975078
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49299928453748
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5069695455873
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47875027450091
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5142013304677
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46035560624252
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51155006270108
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48311105914098
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47103063949625
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48153736709368
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49132188844116
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46332689619852
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49475598021262
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49795309625803
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49799872131113
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47016139071127
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50735388492109
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46958198025534
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43864895579186
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4860079734326
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49191663492725
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48775670297967
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4979888426606
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49402959663342
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49910765222796
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49113274246992
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4918896480183
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5000612361935
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51259016266067
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47630152854599
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51576181985956
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4753253491544
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5089732648422
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50161893106787
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49704796723665
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49701513594373
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49076967042488
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49705853992089
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4846421696614
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49652530678418
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47633732288665
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44508633059029
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48669017640759
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48098799681505
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4777985588028
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46909381794855
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51823713614796
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49444446562352
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46790684185187
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46793933310651
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49283412660014
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.484553592073
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49080283471966
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4628146393287
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48662932594702
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47161262624813
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4331175444359
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47322634009633
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45907995305645
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44931025599037
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4690412389428
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44669075984307
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46899563087663
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4440237408711
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46175789780658
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44674702065606
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47161236971122
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47580438555633
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4509042231686
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4529561994339
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4810322996317
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45537473986634
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48146502861597
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46742309167335
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47105680787557
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47825087077037
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4467289945598
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47935361235771
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45275320649726
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4570620889403
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46902425584591
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46847048481364
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47519786727567
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44965041915567
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4619421304094
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49695442304034
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41746419619592
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4626991914558
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48241783219879
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48223460618682
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44765578345107
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48455180222042
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44909278362485
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.432204889208
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48465602249424
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44977547248637
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43571039272972
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45729835494315
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45182137958915
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42737636999396
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45634480053378
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39878683723715
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4491026220005
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44034543854384
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45477400907235
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46484220701207
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45020609580398
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.441934442275
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43425981318823
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45753022832253
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42747889363524
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43931648501918
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46283448031865
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43050083349287
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45929047003027
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44816546099831
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43002280150193
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45697892433093
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49157137362702
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44127484376561
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44290825066287
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43063978741884
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40290939760962
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39719732931617
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42526449387857
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43758963395292
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42884526503866
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43460022169454
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48047690531025
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41073369370964
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41600482034782
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39965061077932
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44283289654778
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42998946435813
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41741461417212
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42610173392559
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43329873463107
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42579385992686
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41379391015539
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47796204058783
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41334551595786
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41789438451622
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42838995466838
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4102410700602
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42552997468044
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39324251092059
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37712925487968
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40979907548432
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41431989488052
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48645789872187
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39782669355246
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4039797113184
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu-total"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu-total"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42619455509241
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42682282587724
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42410775426252
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37019249269537
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4186044667699
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38840248498492
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3424764939577
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.70870310117597
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52559300830056
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54237553612339
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5288336318494
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56302266901407
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58931281063776
     },
-    "Tags": [
-      "cpu-total",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu-total", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22034632884855
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35239669691653
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42308901964064
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34002990879758
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34818797871901
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3483867690888
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33993370613497
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34449518995534
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36092937293711
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26521969539607
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.17817309925864
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12853858155337
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25683673525072
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27774116383982
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40192566774816
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39807635869448
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30746371052999
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41458164961485
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29918422830714
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22750230085607
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38138110778085
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.335283804457
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23994344625333
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31121921156841
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27416588322427
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3104772615302
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12816781583035
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31173992113708
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2977575919456
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3234569192483
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24701472354072
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36901422982316
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24364160114517
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13165342913994
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.06555329420155
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.20681661099867
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.15677477578488
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31507038095691
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1646307815626
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28666029779275
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38582366037451
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.06123368020093
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14448172460088
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19904062754374
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27351455292457
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42243434477679
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26847369108755
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35263656042463
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.0943128105804
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37695963536578
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.244397590426
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24795723069599
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2905127550885
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29035537139589
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32672117124973
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29420567705681
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.11508357505244
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23981785529794
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30701347284645
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33081813300225
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47681201233156
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34047002527825
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19046325779829
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28171638239031
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34393136815906
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38496433270122
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31930771792457
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24462475734329
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39922866886009
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1776795250873
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4107706143771
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.03666960383445
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14847109747222
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27317519203932
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26025713432252
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22445643096948
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.20180734599008
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37306726109956
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05349887263507
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33126911413848
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37724853098864
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26592326592022
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27796966664926
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39791567005629
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4022931527523
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29838816120599
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13604274938342
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.96723192446224
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19873666701068
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.0987420832102
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.90340024946802
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24782887608025
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41012946830138
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.08629526118936
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30291350620497
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40694033626092
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26606336253322
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18207111110674
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25665022183415
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.93623359713042
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26940363289641
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21975549028865
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32776092732529
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19031938037755
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.86973032074405
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36403287861266
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27780247162546
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31979449809809
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.0325653455874
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35592104242892
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12368384264737
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23201814593762
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19431629729422
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14842146956563
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.310824039792
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18937887475109
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18223578221405
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.09005716366205
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21978501295594
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14863746275893
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.17019379128239
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.08123813681323
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12419544960675
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14857953009938
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33151412192665
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28672536700562
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.10655594575098
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26471680055573
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05368195671393
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23202031943913
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27375084376958
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21537255365809
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26793002133091
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41472549805134
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24482537884234
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42703127090414
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12432582826916
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21944542113961
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3105558611856
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23538532582927
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29047854155488
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2534669486222
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29787541745002
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.15712092347457
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12715832259863
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12356253297895
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.07428753258131
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.11946742598998
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21478721548009
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.20337764336075
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2654517100827
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30697243771458
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22431424966437
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.02454805481631
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1574798633148
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.256157660648
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26512119507322
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16486819200593
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.0864240540144
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31082765295116
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29908080660226
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.99949273417259
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28648691862402
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27339827653276
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2696062789118
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19434014717957
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21941249595191
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22839866851679
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05015922241007
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.98331730302664
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.02792522232731
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16532722062828
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18153824231642
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.20258767279499
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.15782960003241
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24452170368251
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.99874392962947
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28567849688697
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.11956966512201
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29816977985693
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2609491556545
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.09526401841721
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24031201004478
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14843892927054
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22421894912804
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18606609845365
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12038340728832
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2533253363611
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1227123912066
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21043142504703
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16425444793357
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.01277187898239
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1116692102293
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14004897221264
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36399404487787
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14412162747891
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26059583525232
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3148426011204
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19518949921269
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26579529234021
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1743565974831
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13640341933342
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21482411063391
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21255617908645
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12885418882597
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.99880978858958
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21109364694023
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14463264727522
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1151763329655
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26076871781152
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2030109977993
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.17842280161405
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2653164843861
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13705850113409
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13133596769948
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05602946324085
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26517580820759
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2522769738314
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.09419839453238
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29597886960829
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16567504821239
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16486034652151
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1306062302851
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26099956092118
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18663483701151
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13659529705895
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18709108116711
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.01408212286672
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.09504567124573
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22393021944897
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.07444986059924
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16546736832909
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.10786823269386
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.98675663092975
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26885851695035
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.06269873636869
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.98626749318898
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18618505848576
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.15755069672979
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1114444800644
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19820483687089
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05673376123201
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19901762690206
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.10779734347769
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24475828026455
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.17832353291953
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21619063373817
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25668490183186
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2110661122408
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2647109685504
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26525697990725
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.91221931856983
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16157228636486
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16902900727712
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28158067190203
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.06490976289653
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21942606367811
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23202815453647
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18576710383455
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05317313851187
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14816854648979
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14870448735654
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21612435243895
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.09098599484788
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu0"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu0"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.97625269236165
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.20398009991858
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31699342783422
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.294031894672
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33999323183282
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31280428265677
     },
-    "Tags": [
-      "cpu0",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu0", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56731455760415
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46765350811364
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58445653900043
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63808131491884
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49647641985264
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6507391929725
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52120442692622
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33843905675991
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54616082450407
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4802954416636
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58802706047248
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36380524493056
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50909309338927
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55927126089392
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56326370177065
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46370365436411
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65897286611563
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36356979530849
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64239287422764
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50965707281101
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26348142100797
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58014217832317
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45127498605041
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70876080227767
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64633572089268
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31788646454281
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56733953166042
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5464937443745
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44667954644028
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41362130573911
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23463921570395
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6135750959727
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51328456419418
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46795583012084
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4469911336726
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51769202715504
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45075459434115
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33014908722288
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59291494392949
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37151880067451
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67951957583158
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48421799072851
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41777114568184
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46719412344059
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39317004357288
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51782802761151
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31333391360418
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58370744608219
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4925140413185
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3964926466635
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39671362409008
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52203322009734
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51303524302192
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35523593439967
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5218987584736
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42634068481009
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48805531871712
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33501777705055
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42587976398323
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50894996083463
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47163697925969
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57587988189086
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42655120279495
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50125323998077
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40937538791093
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39328467167645
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49234622341767
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62995518312603
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.09269291427819
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54203120303112
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53396431548715
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41814407627031
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44304084081797
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45923074894841
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53031032244132
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6212906105223
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.488455194751
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32187525840261
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54260493762206
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22200185013291
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61332595855897
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58429594319902
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56296463810615
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62952386052848
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43854267336387
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48843803149349
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41961759542369
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23974322939837
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22212491111098
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35196335920672
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37704703764429
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3853039014499
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.17155316608604
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49649723212433
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4303903546121
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46775753387828
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63798940991485
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41374431037794
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61311861852603
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3510046866382
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36002559638604
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35492209842529
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61303556926062
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62140584257794
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3229189553694
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40104387619198
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44229176123798
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50476473149668
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44229643552093
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56342600769233
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37905077335695
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54658964766982
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47636289620146
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39950494228594
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52633509752337
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30131770931958
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45996122418312
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3147227148837
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2639107724686
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32217963013267
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52614786695169
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33412495978719
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31538514365405
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50038050866736
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34647937415384
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58773619791423
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30989872403728
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59636420180999
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50525402967212
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43419919206593
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4381368649104
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5304406927617
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12143784013163
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32642414702114
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41784598976403
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58405103670431
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42203365955153
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3885424405796
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4506761568522
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40463057240261
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55476859409949
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55467265620042
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4390701452349
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37231578892114
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40575557262225
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32600740681828
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46758852813169
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52175525196783
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38889427463863
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55486016262425
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44258043342829
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69170738414418
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55038997904568
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48847939793694
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48009599958935
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47603795626623
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35079094921043
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23864398690678
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47631951153839
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33463088892692
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42990494405358
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43039494607972
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18830064921383
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21416210545682
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4259719600579
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31355857589169
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45524470192335
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58808511324163
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35534864734706
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.17614284761459
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43887428962006
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42574211475925
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45979699377612
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27196177203854
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45129535281376
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50962617663298
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50495167122584
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32563533473741
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42981713391525
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50943370951137
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44661789721071
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43447055868903
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33842182761107
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53375655523242
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.542422607441
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35913844665868
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50441462747898
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30467123408864
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45419811392036
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52622337672487
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.03855684750488
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29488608613237
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38896934093081
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38040072977435
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31790438722436
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2575569834536
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27123483683584
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39699482298778
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.95565965183893
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52953141953954
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54273346075121
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45572989588612
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41698960495917
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34717364749274
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.493019954283
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47200442306247
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.18964565672007
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39324338101925
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41808780463337
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49238401793833
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27594578978977
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39226306187247
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48840888709783
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33425043959807
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32170756916788
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28156368171265
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35084976478977
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.0801096761718
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30168652388285
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41135158414257
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43391045788832
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3679647893597
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39728410485623
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45122785898083
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4554947460615
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30122373365401
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46753094041505
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37315235613367
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.184543662973
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38872354828948
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4798855510606
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22291769379495
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45948690621357
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49269284681024
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40567000182176
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36421452123125
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30879744674225
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48020544164918
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43419174188593
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38794702719436
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21429711486219
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37559641604246
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44264199934132
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42166370847106
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48851691957672
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3305278558239
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.0983868756985
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40996009485265
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2396951486324
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39492746518347
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2312037495151
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37674178538846
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40556396235614
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37197802367815
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48818036571676
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30566499317064
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39726156240344
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13823419670113
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32156482428985
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40539162838961
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24022837987825
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41358729165019
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41794489241545
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.10885289672416
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.0684795749717
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50099800410912
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48823566605415
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60488050181148
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64212337897635
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu1"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu1"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6017487809408
     },
-    "Tags": [
-      "cpu1",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu1", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.78338321670908
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53363600360929
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68752024630014
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56328527668433
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68777431836094
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70844516425002
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67934515535974
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57541960791654
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65869814703393
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68364049582584
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61245340442014
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62971011983568
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40504531251706
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64187814806814
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65430660899891
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57546489595937
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68365745169108
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67534000350882
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59604080932526
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41735023661404
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60456460432282
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.76673274208038
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48802610214922
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55861521763927
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64195308157768
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65045222814199
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36324303064795
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40890930743144
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61284443227687
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47117343558034
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59622366050301
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19664807141613
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63369075170182
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55900118901597
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54650923346128
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6003989432027
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5671563550311
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53380697000843
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45462670853031
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64206118260677
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40445087709236
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62123634020672
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55039390343796
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61668236680818
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57924947472719
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64604513891857
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63788166177811
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55890703617678
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66704483995274
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62132512711473
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42561801918531
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52922769558431
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64208227741564
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65041958211783
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50882750815343
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61727658971218
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70003708759867
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57128612406355
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64170770865265
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4252739177602
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46713563223676
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62511998121839
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.571343851907
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64189913456805
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70838697931441
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56285274084489
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61678592199273
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57551903503072
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67941989759898
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59605294828297
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59612838820561
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60023250221514
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53364120871738
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64177402578372
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60054725339005
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38351479386877
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60458983720832
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6253533060065
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65823278220171
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47957345297192
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56721953207222
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41280896111145
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67096196261036
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46673570333506
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4673521761403
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71671174550238
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55883187796638
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63780734419218
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44689012657936
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41284453974987
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45888173682823
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48336085680684
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39596087117273
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59863204316537
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12548536310594
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45907597364943
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45460015663055
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66256589245556
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71271565225543
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58396095791032
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37929363020356
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47542759039091
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50046903386482
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6457703369709
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53386892659972
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72509121676813
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49645638865643
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57941494309524
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.454440301744
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40002264895399
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43368604062387
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5002852586246
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57116483862812
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55068049985482
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55476439811451
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48660860786468
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5753903189411
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62116927469042
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49643453841752
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41299817869782
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30893906556724
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61301435803188
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52477880469822
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32903046326017
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45507079994212
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50870203217528
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52959394205571
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57097415070041
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54185339675178
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35899338381456
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6002700054742
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5084317079726
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53382703496634
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3835347686646
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5044112307793
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42905722451256
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58779432224709
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6793371295792
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62509097550308
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36351183927097
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24178367406303
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59600279181033
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57522752199236
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62518626309462
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54619050281362
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52968590772565
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37973019258008
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44211559394995
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52542744160478
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39599437991534
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36232689777314
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38398713414496
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53812222277092
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46693831868129
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48805613920017
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45873547684211
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59161569019308
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28803772654224
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63334039982381
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25004818787471
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.1800174574467
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57952369406387
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21771320978144
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56594838974125
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60453586649912
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45498408202984
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50026514992267
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6707824404652
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48371924928664
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51659028941583
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57953605665055
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40036497683239
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50004870091199
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33418813417622
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66670352077291
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45855302292524
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6126743421422
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55059825447911
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64199493146843
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63353204554475
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58796474701654
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47957284360234
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.620678410499
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42525652834082
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59596913283828
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49626897514405
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34631461169346
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50869753116736
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53664267483907
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52095689201617
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59173700439402
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48239183769431
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50862364302667
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5373897241048
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42153386876238
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57530711948193
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46293163673879
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64460337659376
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34919548907862
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.304710740617
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59618249295066
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55348177329067
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57957754204075
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56242371375238
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5249532207768
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6044280981087
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48361382221712
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41315595595097
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29151090187024
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55019865310516
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49551373331512
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21294775415289
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59193628198649
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60034433962507
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4296805043643
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30510861234588
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.569339272364
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52529017669514
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43461785599243
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27129645415324
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48322286198616
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57964765578275
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47142305481573
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62817851679837
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36937302484847
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55435741844745
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42556455594182
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5962943001183
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50474401713518
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48338305634557
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25896326687302
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51719018695734
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40407343931771
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55043158624527
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52536972299241
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64192817281916
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40868938535272
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21272509516507
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55423849524131
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51301067640043
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5294701468827
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42549418940905
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.15464377505818
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44568447580143
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62280867052185
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63356949014913
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45412822074364
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41671095441563
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50035588783267
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36332445830256
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41353288163377
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47969849499016
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3958740668733
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52110681979251
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58347780460589
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24664889881974
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54618193678374
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53777414304388
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41272646184218
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53364900143822
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35015691746763
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2464520915837
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58773711289076
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55038663925073
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31106666923773
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 100
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67335603935844
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2962227936715
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu2"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu2"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51716547725465
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.83083056945351
     },
-    "Tags": [
-      "cpu2",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu2", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71691561843973
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39186964526895
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25108286884131
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42520639597758
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62485311176253
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72915357005768
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75838312506698
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7333372624728
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.73342048783043
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5961434201803
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66278163792224
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34231267830187
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55014530460413
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54617357804385
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56294375473966
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60065245859778
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65033219500118
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61691529495839
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62924076480165
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58344490389787
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47964019403311
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60444384386761
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68352039639073
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.73763697149127
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62940699279328
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71268701315991
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75418712059155
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61273257645716
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.737516349989
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.608361979792
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70016198797214
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61268655607499
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6750325841012
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75019924384314
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66687023813188
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6252034717004
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60005781663955
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66269091720498
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65871967333548
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71672014653666
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70430347210437
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7166284541528
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58804376947332
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48786961467151
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7082537868642
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52502792014985
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42936965474377
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7166456040981
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54587827066467
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46246531596081
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65424868572008
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60419925047415
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59996982789579
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57958956300631
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57933210928415
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62946996414303
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6916535632631
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59581992893624
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53307834405109
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49636719542828
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59180708380062
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67074107471456
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39239675376017
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72085367871716
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.77911209606549
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68343637277162
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68772814835245
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32972750187986
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63623551245813
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57064927517577
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65004878361322
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65454019735766
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59617779062006
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72104947599574
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35879193708062
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5877533629544
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55453605844217
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47931839575483
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59592846360276
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58741192052229
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51666126207637
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48336168768083
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45389026458271
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43343068849067
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52090314616368
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30903013566183
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58340337915979
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5167823772935
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57935356263157
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66685305600141
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28809888514589
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62948255083218
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60027007216644
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63351990599575
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70407460798124
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2124216324374
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30210533428811
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65028208641782
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44983862502524
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68748698733549
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.399890724461
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3922020429814
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3833449622175
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46288093014856
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55009860538122
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67938681368467
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65437754247681
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60802798375198
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56258562136027
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63751185437877
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55461111657714
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66620853641348
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56661909767809
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51314671698334
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54186379962584
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60841160404057
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60419116688438
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59637245958059
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5377313628497
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5376725851885
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33362808954975
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66667010434634
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49259298123098
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56290891274132
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67915333767381
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41276524318143
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61701560205059
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61249517115424
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6375824677939
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44152790303552
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52652276445963
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64578682039429
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5459448398161
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40025636159538
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55861875027388
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37555108919408
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61249072506511
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55422418368506
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30405186858088
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54604811326163
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35026026497069
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32533205150436
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52063628462984
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63334930872058
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.73330807504357
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64177460847128
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3629730211337
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68346188894479
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35417677979534
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44169536294162
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42563413123908
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5249270524452
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50842823080923
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51671168777926
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58343160267803
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35043100329449
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64591554372414
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50021590100799
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50857420151492
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40033124592924
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37941527619525
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6544324092144
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55440313900418
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51690311371833
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26702711402136
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60856170631182
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4424516683746
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34623043922876
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49634677374742
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58370697967786
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25521962025078
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52544790487188
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59622301384026
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49187400143984
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71265305874614
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47957727130658
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66258259224715
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39968650174437
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6417159754522
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28758130879139
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35889408870848
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3001979684837
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50045112008009
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30821437375283
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47131064826642
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39618976007415
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57509897680997
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56274857771865
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51164204037228
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50444818510464
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56308857536546
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56118964959161
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43366063076543
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52072012834022
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43751929557965
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6541702876945
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30390255943264
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63756619160903
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56966260058498
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59174115821533
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70806173584482
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60444860286451
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67913714587117
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67097830514079
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52120692011833
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60801552583621
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57944920075086
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60425768356743
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50426509193069
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42096989753325
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58760783344496
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38803028455094
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56705705266624
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63347026298288
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47084065757838
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57094066675626
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3328124599609
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38523115566618
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53351585035769
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61102488046056
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32082425031119
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45038509076676
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62515694217488
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4780043830907
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45834812995702
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57486989519195
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3908379320272
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3005773555919
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61279527148038
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5711695403654
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26484257177405
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.500414836778
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21275242289704
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46294410680503
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22122149695412
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44158999417958
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46291843167073
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56643239073499
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5960311577196
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50834515427952
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44150626497884
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42948598665559
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35838600366931
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2752675345797
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37516623367416
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62924473108046
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38396906628441
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57498672891798
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58337774546936
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37896125303507
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46712721942043
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34217395219521
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36697367607154
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35005964055252
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56237784310453
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49600309773876
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67090771764684
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49160719066354
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56690329697547
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5627026730824
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40834893255247
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35017102973335
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50431186194162
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21218771803181
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2832038506727
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.79999999981374
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45896592324117
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65855745181621
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu3"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu3"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7542910841675
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29217552865899
     },
-    "Tags": [
-      "cpu3",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu3", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.8166498833401
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68764930196672
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51692657873451
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64178681269907
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60441919651846
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27195587956795
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39260930541205
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69590763391356
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66295670518981
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7043328253302
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57119912692502
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71253715422706
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64231339734545
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50832782132464
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57502837945925
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75424955024529
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57094055096319
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75837055432173
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39243481185072
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70441569327754
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75413716243337
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7209909926283
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53767410129927
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49571520577115
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53783585769418
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67125620013297
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.74170357960257
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66675767564247
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7209412168307
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67939015294725
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6169944812447
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61522862497937
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67937003010881
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7167076515375
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56672804604669
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45873996123673
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64582801166814
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5292446874713
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51678662846818
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68746967029234
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66257881290387
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65015703494731
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62532828951299
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69170800815249
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70845320629695
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64579889260919
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6167075914121
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40829059137549
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54173659626201
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6874661325724
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72950266019178
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64610633729602
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32924038308404
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66255379596224
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65844110876203
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62912341563032
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62929506331989
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70840382109814
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62530293217254
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70421625013928
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50019836807537
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53353643041795
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64186963193868
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63353192681238
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50831891867215
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.79587048761579
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47943864066902
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67931578384457
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67084533796971
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66679056159593
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48769090022223
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33800430239789
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46263692966103
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70824508752912
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6085449558479
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70852442605887
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66662840322998
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67083718721203
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4417193325015
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68786888600486
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39149851311937
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49622778129618
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61266597579196
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57501443977554
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63354060134952
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6376737558104
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26726747251085
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25028464368039
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64596095620946
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66268274279736
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69608983953218
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60854458146993
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66246590011365
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64608199404188
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64597769146089
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57497411712906
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44985273020463
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35061367208056
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72912827115432
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63354066829226
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53378561795988
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60403675317785
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42928822638947
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49197309093906
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46707767437113
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5253325842822
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75835363798608
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55016038516966
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62497412620661
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7251988362574
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62532286682978
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50032725086044
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60032352822533
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44584480471748
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45045093560152
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6834236598574
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64582033794596
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58339918342217
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72493714540508
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6749828163614
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5378357671486
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43340274730177
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58744494545425
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45710097946657
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44437543216024
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70003269153432
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30058067064942
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29156067744742
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40023569718187
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53740773336983
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35861484307215
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57108224362219
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.74996604198958
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56221959252211
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57491147831502
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52100283865057
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60413653705648
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7042036462844
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47939070127006
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62933257682822
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50827780315882
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52480341126908
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66257832175769
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67917862896898
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29949865532548
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63323677065807
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66266149688869
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43371393754738
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62102418495569
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62067857006225
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51696953007438
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6371572059096
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44526897571176
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63730334476026
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58733249920863
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59985762392097
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55426132907861
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64164103293642
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26695373459201
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66234920685413
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5957282712106
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43329923320299
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54165258130001
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33421716067663
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29983555296282
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52544071026459
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64584527946243
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33350931650803
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65812036175794
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5752238019059
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60426133084984
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66257019607797
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3967998029445
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6542953051354
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41241579894817
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59151042627549
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5456454287416
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63354056679152
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63330779999636
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53354018565791
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40016482583023
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5665116204337
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5544490178177
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5666078412159
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13332355801079
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52500281176476
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47946865101392
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57839658010379
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44945488901247
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55865735955418
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70407031194236
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33394847026113
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59984079867769
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57057786000001
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41630610394213
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50842753687999
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62906173708724
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33347521453736
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66246607561374
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63735739898033
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41670764144679
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2632473154225
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53737435768596
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27123535116893
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52100303947957
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63318253305239
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.12413630390131
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37843587366183
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56652780425429
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60017036286082
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70843699643031
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42117718355975
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.23766791331799
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42963150312904
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63326641639729
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55846570112914
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3213808299987
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3961024218889
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60841161172236
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46486483858519
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54980316084236
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49610708581612
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69574964136534
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53339919255764
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53778175295331
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60831183750027
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62374938709077
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45404770800086
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6494774660344
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67085761719765
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67071142106074
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65421618312483
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67065718067973
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60003906398236
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38820586331089
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35069352606259
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57510767567241
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59595319718598
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40413928297032
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6333117793406
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62526086723051
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64030597438379
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62477787604688
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57077803605233
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50807348044026
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25040289766095
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63323577366238
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47977263185822
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50834748674555
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40860768406377
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50456692500155
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6698303991982
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52126119931476
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57096598350279
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44599527959487
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50052734233115
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52460179574713
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71643688639573
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51679074322135
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40306254221245
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59198637352632
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59585658666771
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu4"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu4"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.01726329445115
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56274520486568
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44499936917002
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5000000001135
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37776653503155
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7457329159955
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.74860849481253
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5925763929694
     },
-    "Tags": [
-      "cpu4",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu4", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.81656633285915
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65030324005879
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68371093615787
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5830239050884
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61689056861597
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34624735133558
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53795308938095
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7376203465244
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47520234923961
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57930259805114
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52978451788526
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7377201053817
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7125789875778
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61259903555039
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55436182152414
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49172287143047
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75842024596078
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43369288124426
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56731442474062
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70424872855016
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67096607544089
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54181582518146
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65003697921675
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50041523573488
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.81240400391557
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54611475320372
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.78746204603969
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65020322254236
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43358577388146
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63714079778826
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63811705559469
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65853660521306
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71251212066802
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4171968443132
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6627034138012
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56661991888704
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51708980092174
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64596188781212
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54179485450011
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47921085322359
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58745313800101
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68354912732822
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47524044349653
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50058034169889
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.78749555398225
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64186034420895
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72922459181399
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32963669916597
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64971522374005
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63756202107156
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67099095083962
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69178634031157
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68324527889843
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.570915675317
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72079143314765
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5504607913437
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52075718411358
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63762847043603
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49207673149517
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.77077459166195
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56685281560836
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61274424088316
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70414522863314
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24585136431615
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70008600105375
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72514894336916
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48334503736226
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.674820311431
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68746183765857
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65852404374867
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55862777252071
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.77097007299194
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63351991457664
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49557755899754
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7166411824078
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62904949124136
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54993248343123
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59629298539892
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6289784785702
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67489066471195
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53732338940726
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62529018868817
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56303103021645
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68322848668818
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68324957461145
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6003904117271
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51690738453128
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61690309752048
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28714028093344
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55850286361432
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55436143090348
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67501202929027
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.512660822487
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39631024158471
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52953579230002
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61659082629801
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48744470981823
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57509852535645
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57924858410225
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48351408681594
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65294567831937
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56649904838706
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5710571021301
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67917881217839
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70827021160346
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53363986259988
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49202764912218
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4337019181031
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52837913752444
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.78342026352554
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67513275887733
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60434443098188
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72099543826717
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50843665457244
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41251081904024
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28782689878527
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35079698572815
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69091890923279
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39156558332051
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57078633519826
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67947334606761
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69999960834379
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6625287122534
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68731635817407
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55404434599711
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55041011320101
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70429089290207
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49167340083712
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67090363727725
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69156629962755
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62816703133478
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45400636404365
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49615672713038
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58729930801015
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68352844612203
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.77912854705136
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58352845490926
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59581146288645
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44948941891043
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7250619798624
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64577840394355
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45801176993977
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67503681161946
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70854864870971
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69997850367999
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45465189281161
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41647386718431
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65848693787439
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58751093623101
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4668031470038
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49209017927085
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64172834649848
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65009053330448
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67940703750048
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60829079137056
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60009447228235
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60424942505112
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64989952476293
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64592789984204
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58368892967097
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62503231665744
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44579233213102
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62093700428032
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50808988971414
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55843676265253
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65839535372334
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.29618861619012
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59160342050001
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39208114769816
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57525302154683
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58776511949652
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43790148342464
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59565798286997
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52950742650889
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58769513807356
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6373450203023
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55827007096794
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66657028693216
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16723545807328
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4709018574023
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61251165166824
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57110700077652
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68730774057126
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54181976383369
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60856978107103
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5377566599871
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52517661119623
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62926577511126
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51266961459565
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42293600380764
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63348232616714
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52907762713606
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61254911653951
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49609809505735
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66546509188699
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40264716243406
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55034867860257
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50842357478702
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62486623251287
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69580387879408
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45058025704851
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55834899192911
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.14191437007224
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48334915922322
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49521650065138
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37522750581235
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55729513838861
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60815298601021
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59181175449255
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.11220306847878
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68340760875081
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65440352143726
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33324436144086
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54169897496188
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33012944622548
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36226971082804
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54583271622768
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67088290846588
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7207572236983
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24957937722742
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58782777395305
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.19613161806244
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64174089189403
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.737332982839
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60416589160648
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65430786720037
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.26482209055307
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57050339411255
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39555306994573
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36669477933417
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67899510343189
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.308243159073
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5830860679002
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62053267388315
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35385693542997
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44195734025594
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45797749284604
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40462215881213
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34180665790923
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55847429213048
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49086398238461
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57524026045552
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37499075789587
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49617803888047
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44136989351834
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5247655732748
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47562226597552
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3631288775873
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42919480339377
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5376533875061
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32561874969154
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25840589111688
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5292778224604
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57510351311807
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3625901672374
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57068294953636
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.04269768586681
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47480709844751
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6208032318069
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32121079190917
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45873578156358
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55414531189894
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30012785426823
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35017954974866
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 97.86383026962885
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.00299102714837
     },
-    "Tags": [
-      "cpu5",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu5", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7407080698083
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5874948056325
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60019202815045
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56183770089054
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu5"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu5"]
   },
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.20018235031195
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.77502877136898
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.76253717892486
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67947308268516
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68742469987414
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.74162466657636
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5373111771263
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63753288369237
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72507023745514
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.750036963119
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71238663552752
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59599907499967
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.77076592393344
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48368778613485
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55029792429224
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54579094156075
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36225709849005
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64208534499112
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65837438384318
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.76259513858732
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66692794841441
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52921976359578
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70423718756054
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70008710401466
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31315446889242
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52969770092966
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53339863389358
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7500662668917
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64593224169535
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67509530524678
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75846219603017
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51700624898918
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52084697774877
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6874785044177
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75426590966379
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63750347101039
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64607760545734
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63759450360182
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70837401712093
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60417026257181
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42511497123452
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48348658009546
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7126366552725
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67078698703686
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.16265619454951
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56705675366153
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.77490392882883
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59602672293049
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65402851177606
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46284806708276
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4295552595829
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43354009369654
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7208038291934
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49611046568079
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.73324542889684
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50846058127105
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47099483917317
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64595344725852
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.73338280039074
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.81663732893566
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6041988334802
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34230950483378
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.76257875424166
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58781467198162
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45496728328267
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28349860089746
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63339944185469
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66651624967905
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5669199720922
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7083206456905
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58352850441035
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46277787139019
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.733312128938
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.437445270713
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54151136923134
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60033216079965
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63754924136487
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.79997897061968
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60847023783394
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71670783297547
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67509530509825
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69590771719645
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67925377093688
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6043700969535
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48322758023319
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50840760883369
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7000825504664
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52938229344956
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52047785864721
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40064626343012
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63319530342454
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30469844417416
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.73336637500158
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38808508421539
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64155774128714
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69571589270102
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55460906499239
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54183231643765
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25035486129805
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62523225882681
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70837889599859
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6209658671557
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50408621093625
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6736675132331
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63327033743302
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25784128742067
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21706263442957
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42520237259531
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59550732325629
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42902524956793
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4795612811031
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.74988284966422
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33435525823097
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5710404171301
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53370637207114
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69180767514241
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.20080349675453
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55826119151727
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69589547951158
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67433669839151
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69147449905972
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63777794131643
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35875411613391
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51686974606821
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54605769222918
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30863026747568
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71667469996079
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5333743004901
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72518684705376
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63367726737481
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47490734977386
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.654161961935
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60411575822552
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70832061238237
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32921081975081
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57087410000197
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6294572516277
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48774323899795
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69591170527286
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.500122282686
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69997878726439
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55013509396436
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47947395911267
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49602434199761
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67091560866858
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46691934689075
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.645778536826
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67912004442314
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52491477589315
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5127193894436
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58338674625749
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55007831404112
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57090735919213
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.77913698800536
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34178449256054
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48325058134431
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.27148320546264
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72913702905116
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56687367560613
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64576593262342
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69997037076399
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30511648689884
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65435751729702
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59611541024636
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58749933338511
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48282791802552
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42091415632883
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57914521204775
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59170315453115
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62925375439674
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52131105013683
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67899120739794
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64575786672509
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4675228577337
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05966024737064
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28826309535877
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44171157934886
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48758720403595
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62087859596414
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52902862051731
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48303523326024
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54613564940735
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39180564290153
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60397433233379
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46287289610733
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58357435909785
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52928962727991
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44218005214263
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55819515337701
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.38740292855238
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56664920797118
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52893249047652
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4790480549431
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63752889576375
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57933629853896
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62082369345599
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63766158107494
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42526929055572
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49196144780983
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61281969824715
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.17583575638287
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35019757724963
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43319371135264
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5668695380017
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68322870345658
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67080374571219
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45301697335168
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49184881902947
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53375679458316
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49590650423646
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37093163449534
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65719320781285
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50796476215241
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2216029054003
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67099467152194
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62086617554098
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58721639192287
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67918244194406
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.11331113610488
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67090801652525
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50050853723519
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63750799145112
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.13842843652014
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47889030652341
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37092354247085
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05864705194197
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45833554582686
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44171132894604
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.21705153494668
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.36647723303135
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50861954806577
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39086955310228
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50442418493606
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5123865775282
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53729934913004
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56663244196262
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4460318007361
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65429884323412
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46676073010958
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40447717268319
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33379641584237
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50834888389659
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69589962519848
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32562739915551
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59581626646046
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22121075426539
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63336619960465
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39162365039095
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37556061547728
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43766955566555
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49184937564276
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39586982171171
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49208937255355
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35810181354908
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62924486386646
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52128123108865
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51686575973923
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33362055851767
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25014468944376
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49946084109963
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46701683519318
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47921979608253
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54593245033608
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43747432450836
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 98.10233187965162
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6999999997206
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu6"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55920217021207
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7707308635947
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64610238427217
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.82300733011235
     },
-    "Tags": [
-      "cpu6",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu6", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39968258263752
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62508225106463
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629159840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.76249940817756
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.79996634149013
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62519300576558
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629160560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.80413729589061
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629160800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67084100817362
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40474234580235
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40397740304586
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48336475737848
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629161760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70837059586512
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.637619157715
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57935332223661
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.78318292428963
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6584449966125
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629162960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68380869493869
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629163200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58338683752667
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71272000528243
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6500571501132
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629163920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65035739363258
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70841222110671
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60831123641496
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69172461707802
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629164880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55433678818942
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64609087546502
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65403190514648
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41679378101242
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629165840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40812414942054
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6710613143561
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67922800488752
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629166560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72925763363547
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629166800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.76235801619606
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629167040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52083654517186
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61259097516705
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55425571056672
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629167760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72088679641513
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72491634129426
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72488652619724
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72925761831657
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59578272510986
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629168960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54606140542886
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44534414142397
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70019949257578
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.76249122453571
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629169920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7292119877842
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629170160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44190915193724
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68363626620982
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68749537903581
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629170880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59158635233489
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629171120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70844557934855
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629171360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6418411590863
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6832620705322
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629171840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48394244802058
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.73330774168215
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46229068943553
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629172560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52087419997831
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629172800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67516156424449
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629173040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6249645540936
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53371434765131
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52937341798902
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629173760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72930357205722
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629174000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47536445531473
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64583272480719
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60417047083241
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57085776680248
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629174960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65013189347765
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61692386036579
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65846177981547
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629175680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62519062744575
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629175920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55867724227248
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44659988087373
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64584083372266
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67102395186852
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629176880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72083295018143
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70423278396235
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59172027960297
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72506220436377
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629177840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54574918288625
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63356160586257
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70842445000885
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67511989713547
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629178800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52099793670418
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5080393780381
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.74178706297204
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629179520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6625991176873
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629179760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.704236913258
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61248294157679
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57918202672613
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629180480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52509477982511
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31763341684488
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629180960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56285629837191
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59177306175057
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75419539587546
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629181680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63336624998065
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629181920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57969378559356
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69181200503932
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71247445059583
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60838255762705
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629182880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66225731383751
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65417038762011
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629183360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72494945836827
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70828302471926
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629183840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65026085120702
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51653280730848
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.75413290808727
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57064921509213
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629184800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60422454156894
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.64566177872818
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59143955841812
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.22533538311477
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629185760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40857568425086
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.30029588311866
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629186240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3959655504997
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629186480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62919541211966
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54179505472825
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629186960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67094101755485
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69574521211912
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51159977402823
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65421196261252
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629187920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6460656274062
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51283179588889
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59961127676324
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629188640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.69159559566613
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629188880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.31375973683704
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629189120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53755343653002
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58340331294096
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61236137694677
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629189840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62931565063748
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4249068247464
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67067427437019
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62111544414957
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629190800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.35864853610042
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68324957431076
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72506619219219
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49532726698192
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629191760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44194875136633
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24234712393873
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.44558556658721
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70005372985469
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57539788967334
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629192960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.68749108302238
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66229521955164
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.333023031098
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.20444796817388
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629193920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50043893381752
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63772780720956
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.55450741837548
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629194640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3585352995728
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629194880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6332118865745
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6334696310442
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66263292540843
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629195600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41262744535835
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629195840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4662696181159
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.15482193012538
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50441393864946
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71662857860413
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629196800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59586583297455
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7125075003767
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52942741435051
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70834524566332
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629197760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56704411662213
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629198000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62057018652114
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.72939080961852
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629198480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66654893974538
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58359024431395
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629198960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.512190837348
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59623215235422
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4422971009999
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49997007092122
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629199920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65833265752576
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56242824528825
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47523552544374
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.43783908795886
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629200880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65846615035376
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58346913136783
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.63739548744672
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629201600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.32086483442866
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629201840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50852832197779
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48756105482904
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51659782144947
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629202560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67495345383043
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629202800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5835534884187
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.49601968882178
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50052616662039
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6164991818182
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629203760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67930359668414
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629204000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66654523715765
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629204240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52102850402332
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45436150453527
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57096113918463
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629204960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71653251558091
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629205200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59956742072478
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57081049457692
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57516185449454
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629205920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66239536224514
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.41654526214234
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.76239137496297
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629206640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.34612810585428
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629206880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.60391567288788
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.24232531996854
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52941880864677
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57118942524373
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629207840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.65835785812862
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.51060647725048
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.05083182117244
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28316962838682
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629208800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59572372432018
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56228585242087
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.50412331022939
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629209520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71237853677519
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629209760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39589894107313
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6999952466377
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54998694568745
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.57482393206776
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67919527112717
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629210960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.66679081761721
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53803092092788
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.71993446892152
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.637590899438
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629211920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70414965813164
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629212160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54585335412291
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5541116533804
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5541036954662
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629212880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.37108822051577
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54592428413544
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.658236796081
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.62921063133302
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629213840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47096880678366
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52074400622958
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.33729787507558
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56666543308495
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629214800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67498215065973
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53734516149864
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61661916804691
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5959744003269
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629215760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.46248610487665
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54145310275923
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45005219820906
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.48782836326001
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.2254509973355
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629216960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.58107903830121
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217200,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45040578039938
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629217440,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56684831095777
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629217680,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.67065361180327
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629217920,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5497101958983
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218160,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53745685252382
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218400,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45865747627711
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218640,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.5413239477843
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629218880,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42938145697758
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219120,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.61983149369563
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219360,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.45035680267097
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219600,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.59161129622457
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629219840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.40876096557514
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.39611757163192
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629220320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.53597391317221
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629220560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.47528967748606
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629220800,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3207911414441
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221040,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.4874559354263
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629221280,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.54171177919538
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221520,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.6167362474514
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629221760,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.3005608058765
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222000,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.56699522184441
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222240,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.52089485353679
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222480,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.42949912647975
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222720,
-    "Data": {
+    "Measurements": {
       "usage_idle": 97.48891272594233
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629222960,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.79979979961317
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629237840,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.7272902442485
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238080,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.28438186142775
     },
-    "Tags": [
-      "DESKTOP-2BSF9I6",
-      "cpu7"
-    ]
+    "Tags": ["DESKTOP-2BSF9I6", "cpu7"]
   },
   {
     "Time": 1629238320,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.25511662198561
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   },
   {
     "Time": 1629238560,
-    "Data": {
+    "Measurements": {
       "usage_idle": 99.70026052544372
     },
-    "Tags": [
-      "cpu7",
-      "DESKTOP-2BSF9I6"
-    ]
+    "Tags": ["cpu7", "DESKTOP-2BSF9I6"]
   }
 ]

--- a/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()
+++ b/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()
@@ -1,6 +1,7 @@
 ([]observations.Observation) (len=1443) {
   (observations.Observation) {
     Time: (int64) 1605312000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16254.51,
       (string) (len=4) "high": (float64) 16339.6,
@@ -13,6 +14,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605313800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16305,
       (string) (len=4) "high": (float64) 16305,
@@ -25,6 +27,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605315600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16222.16,
       (string) (len=4) "high": (float64) 16303.88,
@@ -37,6 +40,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605317400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16214.15,
       (string) (len=4) "high": (float64) 16246.92,
@@ -49,6 +53,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605319200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16223.08,
       (string) (len=4) "high": (float64) 16234,
@@ -61,6 +66,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605321000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16185.68,
       (string) (len=4) "high": (float64) 16247.6,
@@ -73,6 +79,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605322800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16202.24,
       (string) (len=4) "high": (float64) 16218.42,
@@ -85,6 +92,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605324600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16194.21,
       (string) (len=4) "high": (float64) 16206.58,
@@ -97,6 +105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605326400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16159.4,
       (string) (len=4) "high": (float64) 16208.45,
@@ -109,6 +118,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605328200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16152.36,
       (string) (len=4) "high": (float64) 16170.29,
@@ -121,6 +131,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605330000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16100.84,
       (string) (len=4) "high": (float64) 16148.09,
@@ -133,6 +144,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605331800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16180.01,
       (string) (len=4) "high": (float64) 16185.85,
@@ -145,6 +157,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605333600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16191.84,
       (string) (len=4) "high": (float64) 16223.37,
@@ -157,6 +170,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605335400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16188.67,
       (string) (len=4) "high": (float64) 16206.85,
@@ -169,6 +183,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605337200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16061.94,
       (string) (len=4) "high": (float64) 16201.83,
@@ -181,6 +196,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605339000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16102.09,
       (string) (len=4) "high": (float64) 16114.1,
@@ -193,6 +209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605340800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15885.37,
       (string) (len=4) "high": (float64) 16140.01,
@@ -205,6 +222,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605342600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15976.37,
       (string) (len=4) "high": (float64) 15979.96,
@@ -217,6 +235,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605344400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15906.38,
       (string) (len=4) "high": (float64) 15976.38,
@@ -229,6 +248,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605346200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15805,
       (string) (len=4) "high": (float64) 15906.38,
@@ -241,6 +261,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605348000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15935.31,
       (string) (len=4) "high": (float64) 15942.46,
@@ -253,6 +274,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605349800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15867.22,
       (string) (len=4) "high": (float64) 15957.48,
@@ -265,6 +287,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605351600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15930,
       (string) (len=4) "high": (float64) 15936.91,
@@ -277,6 +300,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605353400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15945.38,
       (string) (len=4) "high": (float64) 15956.04,
@@ -289,6 +313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605355200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15871.4,
       (string) (len=4) "high": (float64) 15948.1,
@@ -301,6 +326,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605357000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15925.01,
       (string) (len=4) "high": (float64) 15933.82,
@@ -313,6 +339,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605358800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15936.47,
       (string) (len=4) "high": (float64) 15937.77,
@@ -325,6 +352,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605360600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15944.34,
       (string) (len=4) "high": (float64) 15953.61,
@@ -337,6 +365,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605362400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16040.28,
       (string) (len=4) "high": (float64) 16046.36,
@@ -349,6 +378,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605364200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16026.12,
       (string) (len=4) "high": (float64) 16072.83,
@@ -361,6 +391,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605366000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16010.37,
       (string) (len=4) "high": (float64) 16046.55,
@@ -373,6 +404,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605367800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15966.15,
       (string) (len=4) "high": (float64) 16021.39,
@@ -385,6 +417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605369600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16013.58,
       (string) (len=4) "high": (float64) 16041.67,
@@ -397,6 +430,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605371400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15865.37,
       (string) (len=4) "high": (float64) 16015.21,
@@ -409,6 +443,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605373200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15877.48,
       (string) (len=4) "high": (float64) 15893.54,
@@ -421,6 +456,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605375000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15922.8,
       (string) (len=4) "high": (float64) 15942.81,
@@ -433,6 +469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605376800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15936.68,
       (string) (len=4) "high": (float64) 15968.98,
@@ -445,6 +482,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605378600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15915.01,
       (string) (len=4) "high": (float64) 15950,
@@ -457,6 +495,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605380400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15898.93,
       (string) (len=4) "high": (float64) 15932.52,
@@ -469,6 +508,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605382200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15900.72,
       (string) (len=4) "high": (float64) 15919.19,
@@ -481,6 +521,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605384000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15930.69,
       (string) (len=4) "high": (float64) 15943.49,
@@ -493,6 +534,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605385800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16009.69,
       (string) (len=4) "high": (float64) 16019.41,
@@ -505,6 +547,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605387600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16007.74,
       (string) (len=4) "high": (float64) 16040,
@@ -517,6 +560,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605389400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16009.52,
       (string) (len=4) "high": (float64) 16050,
@@ -529,6 +573,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605391200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16027.35,
       (string) (len=4) "high": (float64) 16051.63,
@@ -541,6 +586,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605393000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16051.89,
       (string) (len=4) "high": (float64) 16051.89,
@@ -553,6 +599,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605394800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16107.01,
       (string) (len=4) "high": (float64) 16161.51,
@@ -565,6 +612,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605396600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16082.01,
       (string) (len=4) "high": (float64) 16132.61,
@@ -577,6 +625,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605398400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16092.07,
       (string) (len=4) "high": (float64) 16123.67,
@@ -589,6 +638,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605400200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16059.01,
       (string) (len=4) "high": (float64) 16098.21,
@@ -601,6 +651,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605402000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16005.24,
       (string) (len=4) "high": (float64) 16094.12,
@@ -613,6 +664,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605403800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15998.38,
       (string) (len=4) "high": (float64) 16027.06,
@@ -625,6 +677,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605405600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16005.95,
       (string) (len=4) "high": (float64) 16047.56,
@@ -637,6 +690,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605407400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15998.75,
       (string) (len=4) "high": (float64) 16014.43,
@@ -649,6 +703,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605409200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15930,
       (string) (len=4) "high": (float64) 16002.34,
@@ -661,6 +716,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605411000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15946.09,
       (string) (len=4) "high": (float64) 15950.79,
@@ -673,6 +729,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605412800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15967.64,
       (string) (len=4) "high": (float64) 15973.43,
@@ -685,6 +742,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605414600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15949.05,
       (string) (len=4) "high": (float64) 15968.58,
@@ -697,6 +755,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605416400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16007.18,
       (string) (len=4) "high": (float64) 16011.94,
@@ -709,6 +768,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605418200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16033.32,
       (string) (len=4) "high": (float64) 16033.33,
@@ -721,6 +781,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605420000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16051.81,
       (string) (len=4) "high": (float64) 16055.5,
@@ -733,6 +794,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605421800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16069.26,
       (string) (len=4) "high": (float64) 16097.57,
@@ -745,6 +807,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605423600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16046.17,
       (string) (len=4) "high": (float64) 16111.68,
@@ -757,6 +820,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605425400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16045.93,
       (string) (len=4) "high": (float64) 16051.32,
@@ -769,6 +833,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605427200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16146.63,
       (string) (len=4) "high": (float64) 16153.4,
@@ -781,6 +846,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605429000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16135.46,
       (string) (len=4) "high": (float64) 16175.6,
@@ -793,6 +859,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605430800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16109.67,
       (string) (len=4) "high": (float64) 16143.95,
@@ -805,6 +872,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605432600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16082.41,
       (string) (len=4) "high": (float64) 16111.89,
@@ -817,6 +885,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605434400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15999.88,
       (string) (len=4) "high": (float64) 16107.1,
@@ -829,6 +898,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605436200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16007.41,
       (string) (len=4) "high": (float64) 16033.07,
@@ -841,6 +911,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605438000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16069.91,
       (string) (len=4) "high": (float64) 16080.52,
@@ -853,6 +924,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605439800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15972.08,
       (string) (len=4) "high": (float64) 16112.36,
@@ -865,6 +937,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605441600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16047.88,
       (string) (len=4) "high": (float64) 16081.16,
@@ -877,6 +950,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605443400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15993.78,
       (string) (len=4) "high": (float64) 16082.94,
@@ -889,6 +963,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605445200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16048.49,
       (string) (len=4) "high": (float64) 16065.74,
@@ -901,6 +976,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605447000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16062.34,
       (string) (len=4) "high": (float64) 16094,
@@ -913,6 +989,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605448800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16090.62,
       (string) (len=4) "high": (float64) 16122.97,
@@ -925,6 +1002,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605450600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16064.02,
       (string) (len=4) "high": (float64) 16102.73,
@@ -937,6 +1015,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605452400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16054,
       (string) (len=4) "high": (float64) 16087.57,
@@ -949,6 +1028,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605454200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16041.73,
       (string) (len=4) "high": (float64) 16055.56,
@@ -961,6 +1041,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605456000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15985.29,
       (string) (len=4) "high": (float64) 16079.39,
@@ -973,6 +1054,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605457800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16020.01,
       (string) (len=4) "high": (float64) 16025.96,
@@ -985,6 +1067,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605459600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15997.23,
       (string) (len=4) "high": (float64) 16020.01,
@@ -997,6 +1080,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605461400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15900.01,
       (string) (len=4) "high": (float64) 15996.5,
@@ -1009,6 +1093,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605463200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15940.01,
       (string) (len=4) "high": (float64) 15959.2,
@@ -1021,6 +1106,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605465000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15916.83,
       (string) (len=4) "high": (float64) 15948,
@@ -1033,6 +1119,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605466800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15928.17,
       (string) (len=4) "high": (float64) 15949.75,
@@ -1045,6 +1132,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605468600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15882.05,
       (string) (len=4) "high": (float64) 15928.35,
@@ -1057,6 +1145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605470400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15832.86,
       (string) (len=4) "high": (float64) 15900,
@@ -1069,6 +1158,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605472200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15858.88,
       (string) (len=4) "high": (float64) 15880.01,
@@ -1081,6 +1171,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605474000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15888.93,
       (string) (len=4) "high": (float64) 15919.43,
@@ -1093,6 +1184,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605475800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15856.67,
       (string) (len=4) "high": (float64) 15908,
@@ -1105,6 +1197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605477600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15845.29,
       (string) (len=4) "high": (float64) 15864.07,
@@ -1117,6 +1210,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605479400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15939.93,
       (string) (len=4) "high": (float64) 15978,
@@ -1129,6 +1223,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605481200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15996.76,
       (string) (len=4) "high": (float64) 16021.75,
@@ -1141,6 +1236,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605483000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15966.89,
       (string) (len=4) "high": (float64) 16018.57,
@@ -1153,6 +1249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605484800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15909.22,
       (string) (len=4) "high": (float64) 15970,
@@ -1165,6 +1262,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605486600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15989.99,
       (string) (len=4) "high": (float64) 15992.17,
@@ -1177,6 +1275,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605488400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15990.93,
       (string) (len=4) "high": (float64) 16055.63,
@@ -1189,6 +1288,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605490200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15959.5,
       (string) (len=4) "high": (float64) 16020.64,
@@ -1201,6 +1301,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605492000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15967.68,
       (string) (len=4) "high": (float64) 16015,
@@ -1213,6 +1314,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605493800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15946.27,
       (string) (len=4) "high": (float64) 15977.55,
@@ -1225,6 +1327,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605495600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15989.39,
       (string) (len=4) "high": (float64) 15994.11,
@@ -1237,6 +1340,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605497400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16020.98,
       (string) (len=4) "high": (float64) 16053.93,
@@ -1249,6 +1353,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605499200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16032.84,
       (string) (len=4) "high": (float64) 16050,
@@ -1261,6 +1366,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605501000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16045.3,
       (string) (len=4) "high": (float64) 16048.24,
@@ -1273,6 +1379,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605502800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16133.96,
       (string) (len=4) "high": (float64) 16149.63,
@@ -1285,6 +1392,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605504600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16125.97,
       (string) (len=4) "high": (float64) 16150.99,
@@ -1297,6 +1405,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605506400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16217.32,
       (string) (len=4) "high": (float64) 16244.95,
@@ -1309,6 +1418,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605508200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16250.01,
       (string) (len=4) "high": (float64) 16260.99,
@@ -1321,6 +1431,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605510000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16254,
       (string) (len=4) "high": (float64) 16300,
@@ -1333,6 +1444,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605511800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16254.69,
       (string) (len=4) "high": (float64) 16277.53,
@@ -1345,6 +1457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605513600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16250.06,
       (string) (len=4) "high": (float64) 16286.27,
@@ -1357,6 +1470,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605515400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16225.04,
       (string) (len=4) "high": (float64) 16270,
@@ -1369,6 +1483,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605517200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16204.65,
       (string) (len=4) "high": (float64) 16248.83,
@@ -1381,6 +1496,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605519000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16237.63,
       (string) (len=4) "high": (float64) 16237.63,
@@ -1393,6 +1509,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605520800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16345,
       (string) (len=4) "high": (float64) 16345,
@@ -1405,6 +1522,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605522600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16392.89,
       (string) (len=4) "high": (float64) 16392.89,
@@ -1417,6 +1535,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605524400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16383.44,
       (string) (len=4) "high": (float64) 16398,
@@ -1429,6 +1548,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605526200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16232.03,
       (string) (len=4) "high": (float64) 16383.44,
@@ -1441,6 +1561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605528000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16304.38,
       (string) (len=4) "high": (float64) 16313.59,
@@ -1453,6 +1574,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605529800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16320.34,
       (string) (len=4) "high": (float64) 16320.34,
@@ -1465,6 +1587,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605531600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16305.91,
       (string) (len=4) "high": (float64) 16352.06,
@@ -1477,6 +1600,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605533400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16326.95,
       (string) (len=4) "high": (float64) 16380.99,
@@ -1489,6 +1613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605535200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16415.9,
       (string) (len=4) "high": (float64) 16422,
@@ -1501,6 +1626,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605537000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16409.16,
       (string) (len=4) "high": (float64) 16447,
@@ -1513,6 +1639,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605538800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16410,
       (string) (len=4) "high": (float64) 16439,
@@ -1525,6 +1652,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605540600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16463.62,
       (string) (len=4) "high": (float64) 16476,
@@ -1537,6 +1665,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605542400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16608.68,
       (string) (len=4) "high": (float64) 16639.66,
@@ -1549,6 +1678,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605544200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16578.83,
       (string) (len=4) "high": (float64) 16660,
@@ -1561,6 +1691,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605546000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16747.99,
       (string) (len=4) "high": (float64) 16748,
@@ -1573,6 +1704,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605547800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16695,
       (string) (len=4) "high": (float64) 16777,
@@ -1585,6 +1717,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605549600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16691.26,
       (string) (len=4) "high": (float64) 16761.7,
@@ -1597,6 +1730,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605551400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16710,
       (string) (len=4) "high": (float64) 16749.42,
@@ -1609,6 +1743,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605553200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16842.6,
       (string) (len=4) "high": (float64) 16859.95,
@@ -1621,6 +1756,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605555000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16797.62,
       (string) (len=4) "high": (float64) 16842.61,
@@ -1633,6 +1769,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605556800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16854.77,
       (string) (len=4) "high": (float64) 16857.73,
@@ -1645,6 +1782,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605558600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16839.44,
       (string) (len=4) "high": (float64) 16857.98,
@@ -1657,6 +1795,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605560400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16821.15,
       (string) (len=4) "high": (float64) 16892,
@@ -1669,6 +1808,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605562200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16705.77,
       (string) (len=4) "high": (float64) 16821.15,
@@ -1681,6 +1821,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605564000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16676.41,
       (string) (len=4) "high": (float64) 16760.77,
@@ -1693,6 +1834,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605565800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16720.81,
       (string) (len=4) "high": (float64) 16794.18,
@@ -1705,6 +1847,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605567600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16783.13,
       (string) (len=4) "high": (float64) 16798,
@@ -1717,6 +1860,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605569400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16726.64,
       (string) (len=4) "high": (float64) 16784.25,
@@ -1729,6 +1873,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605571200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16764.55,
       (string) (len=4) "high": (float64) 16772.43,
@@ -1741,6 +1886,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605573000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16823.64,
       (string) (len=4) "high": (float64) 16844,
@@ -1753,6 +1899,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605574800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16740.43,
       (string) (len=4) "high": (float64) 16823.63,
@@ -1765,6 +1912,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605576600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16706.79,
       (string) (len=4) "high": (float64) 16762.06,
@@ -1777,6 +1925,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605578400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16738.11,
       (string) (len=4) "high": (float64) 16767.38,
@@ -1789,6 +1938,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605580200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16694.45,
       (string) (len=4) "high": (float64) 16738.72,
@@ -1801,6 +1951,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605582000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16619.63,
       (string) (len=4) "high": (float64) 16722.53,
@@ -1813,6 +1964,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605583800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16590.01,
       (string) (len=4) "high": (float64) 16650.01,
@@ -1825,6 +1977,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605585600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16659.14,
       (string) (len=4) "high": (float64) 16676.25,
@@ -1837,6 +1990,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605587400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16686.59,
       (string) (len=4) "high": (float64) 16690,
@@ -1849,6 +2003,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605589200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16635.22,
       (string) (len=4) "high": (float64) 16686.59,
@@ -1861,6 +2016,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605591000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16634,
       (string) (len=4) "high": (float64) 16685,
@@ -1873,6 +2029,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605592800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16672.23,
       (string) (len=4) "high": (float64) 16675.75,
@@ -1885,6 +2042,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605594600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16637.63,
       (string) (len=4) "high": (float64) 16684.68,
@@ -1897,6 +2055,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605596400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16744.45,
       (string) (len=4) "high": (float64) 16762.77,
@@ -1909,6 +2068,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605598200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16756.02,
       (string) (len=4) "high": (float64) 16790,
@@ -1921,6 +2081,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605600000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16735.46,
       (string) (len=4) "high": (float64) 16797.82,
@@ -1933,6 +2094,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605601800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16712.24,
       (string) (len=4) "high": (float64) 16750,
@@ -1945,6 +2107,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605603600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16683.86,
       (string) (len=4) "high": (float64) 16757.57,
@@ -1957,6 +2120,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605605400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16658.16,
       (string) (len=4) "high": (float64) 16695.46,
@@ -1969,6 +2133,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605607200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16736.84,
       (string) (len=4) "high": (float64) 16740.43,
@@ -1981,6 +2146,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605609000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16783.73,
       (string) (len=4) "high": (float64) 16785,
@@ -1993,6 +2159,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605610800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16940.25,
       (string) (len=4) "high": (float64) 16943.99,
@@ -2005,6 +2172,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605612600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16999.41,
       (string) (len=4) "high": (float64) 17000,
@@ -2017,6 +2185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605614400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17012.95,
       (string) (len=4) "high": (float64) 17081.38,
@@ -2029,6 +2198,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605616200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17094.97,
       (string) (len=4) "high": (float64) 17100,
@@ -2041,6 +2211,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605618000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17031.47,
       (string) (len=4) "high": (float64) 17100,
@@ -2053,6 +2224,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605619800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16957.88,
       (string) (len=4) "high": (float64) 17061.92,
@@ -2065,6 +2237,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605621600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17059.61,
       (string) (len=4) "high": (float64) 17080,
@@ -2077,6 +2250,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605623400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17181.67,
       (string) (len=4) "high": (float64) 17207,
@@ -2089,6 +2263,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605625200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17219.57,
       (string) (len=4) "high": (float64) 17247,
@@ -2101,6 +2276,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605627000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17355.87,
       (string) (len=4) "high": (float64) 17398,
@@ -2113,6 +2289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605628800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17400,
       (string) (len=4) "high": (float64) 17400,
@@ -2125,6 +2302,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605630600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17668.83,
       (string) (len=4) "high": (float64) 17756.67,
@@ -2137,6 +2315,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605632400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17639.5,
       (string) (len=4) "high": (float64) 17750,
@@ -2149,6 +2328,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605634200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17834.89,
       (string) (len=4) "high": (float64) 17880,
@@ -2161,6 +2341,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605636000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17745.32,
       (string) (len=4) "high": (float64) 17849.31,
@@ -2173,6 +2354,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605637800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17650.9,
       (string) (len=4) "high": (float64) 17850,
@@ -2185,6 +2367,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605639600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17685.76,
       (string) (len=4) "high": (float64) 17722,
@@ -2197,6 +2380,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605641400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17699.45,
       (string) (len=4) "high": (float64) 17774.12,
@@ -2209,6 +2393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605643200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17646,
       (string) (len=4) "high": (float64) 17745,
@@ -2221,6 +2406,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605645000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17691.72,
       (string) (len=4) "high": (float64) 17738.62,
@@ -2233,6 +2419,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605646800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17562.76,
       (string) (len=4) "high": (float64) 17720.65,
@@ -2245,6 +2432,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605648600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17644.32,
       (string) (len=4) "high": (float64) 17684.55,
@@ -2257,6 +2445,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605650400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17569.14,
       (string) (len=4) "high": (float64) 17648.12,
@@ -2269,6 +2458,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605652200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17619.62,
       (string) (len=4) "high": (float64) 17624.25,
@@ -2281,6 +2471,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605654000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17667.31,
       (string) (len=4) "high": (float64) 17721.53,
@@ -2293,6 +2484,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605655800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17679.36,
       (string) (len=4) "high": (float64) 17722.76,
@@ -2305,6 +2497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605657600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17772.62,
       (string) (len=4) "high": (float64) 17845,
@@ -2317,6 +2510,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605659400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17718,
       (string) (len=4) "high": (float64) 17796.3,
@@ -2329,6 +2523,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605661200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17710.43,
       (string) (len=4) "high": (float64) 17718.65,
@@ -2341,6 +2536,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605663000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17764.05,
       (string) (len=4) "high": (float64) 17765.85,
@@ -2353,6 +2549,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605664800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17712.96,
       (string) (len=4) "high": (float64) 17762.44,
@@ -2365,6 +2562,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605666600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17702.62,
       (string) (len=4) "high": (float64) 17745.85,
@@ -2377,6 +2575,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605668400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17732.3,
       (string) (len=4) "high": (float64) 17734.3,
@@ -2389,6 +2588,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605670200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18059.1,
       (string) (len=4) "high": (float64) 18095,
@@ -2401,6 +2601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605672000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18181.25,
       (string) (len=4) "high": (float64) 18288,
@@ -2413,6 +2614,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605673800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18390.49,
       (string) (len=4) "high": (float64) 18488,
@@ -2425,6 +2627,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605675600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18267.37,
       (string) (len=4) "high": (float64) 18390.52,
@@ -2437,6 +2640,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605677400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17639.68,
       (string) (len=4) "high": (float64) 18286.15,
@@ -2449,6 +2653,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605679200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17767.11,
       (string) (len=4) "high": (float64) 17894.68,
@@ -2461,6 +2666,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605681000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17792.99,
       (string) (len=4) "high": (float64) 17850,
@@ -2473,6 +2679,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605682800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17778.27,
       (string) (len=4) "high": (float64) 17861.31,
@@ -2485,6 +2692,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605684600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18089.38,
       (string) (len=4) "high": (float64) 18110.86,
@@ -2497,6 +2705,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605686400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18163.98,
       (string) (len=4) "high": (float64) 18237.86,
@@ -2509,6 +2718,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605688200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18227.35,
       (string) (len=4) "high": (float64) 18282.3,
@@ -2521,6 +2731,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605690000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17952.5,
       (string) (len=4) "high": (float64) 18242.81,
@@ -2533,6 +2744,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605691800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18122.99,
       (string) (len=4) "high": (float64) 18151.26,
@@ -2545,6 +2757,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605693600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18152.56,
       (string) (len=4) "high": (float64) 18172.78,
@@ -2557,6 +2770,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605695400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18265.85,
       (string) (len=4) "high": (float64) 18267.15,
@@ -2569,6 +2783,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605697200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18135.16,
       (string) (len=4) "high": (float64) 18267.83,
@@ -2581,6 +2796,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605699000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18266.09,
       (string) (len=4) "high": (float64) 18269.16,
@@ -2593,6 +2809,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605700800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18200,
       (string) (len=4) "high": (float64) 18269.15,
@@ -2605,6 +2822,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605702600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18043.18,
       (string) (len=4) "high": (float64) 18220.68,
@@ -2617,6 +2835,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605704400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18001.14,
       (string) (len=4) "high": (float64) 18117.2,
@@ -2629,6 +2848,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605706200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17898.7,
       (string) (len=4) "high": (float64) 18100,
@@ -2641,6 +2861,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605708000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17881.63,
       (string) (len=4) "high": (float64) 17965.41,
@@ -2653,6 +2874,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605709800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17704.83,
       (string) (len=4) "high": (float64) 17896.24,
@@ -2665,6 +2887,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605711600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17581.66,
       (string) (len=4) "high": (float64) 17740.31,
@@ -2677,6 +2900,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605713400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17896.84,
       (string) (len=4) "high": (float64) 17930,
@@ -2689,6 +2913,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605715200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17909.21,
       (string) (len=4) "high": (float64) 18029.78,
@@ -2701,6 +2926,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605717000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17819.85,
       (string) (len=4) "high": (float64) 17980,
@@ -2713,6 +2939,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605718800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17794.85,
       (string) (len=4) "high": (float64) 17896.79,
@@ -2725,6 +2952,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605720600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17903.99,
       (string) (len=4) "high": (float64) 17934.76,
@@ -2737,6 +2965,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605722400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17871.44,
       (string) (len=4) "high": (float64) 17980,
@@ -2749,6 +2978,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605724200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17785.05,
       (string) (len=4) "high": (float64) 17922.88,
@@ -2761,6 +2991,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605726000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17666.18,
       (string) (len=4) "high": (float64) 17850,
@@ -2773,6 +3004,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605727800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17671.91,
       (string) (len=4) "high": (float64) 17750,
@@ -2785,6 +3017,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605729600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17587.22,
       (string) (len=4) "high": (float64) 17741.13,
@@ -2797,6 +3030,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605731400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17655.65,
       (string) (len=4) "high": (float64) 17680,
@@ -2809,6 +3043,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605733200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17698.63,
       (string) (len=4) "high": (float64) 17766.6,
@@ -2821,6 +3056,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605735000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17785.63,
       (string) (len=4) "high": (float64) 17800,
@@ -2833,6 +3069,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605736800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17735.69,
       (string) (len=4) "high": (float64) 17849.99,
@@ -2845,6 +3082,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605738600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17834.51,
       (string) (len=4) "high": (float64) 17881.76,
@@ -2857,6 +3095,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605740400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17729,
       (string) (len=4) "high": (float64) 17865.29,
@@ -2869,6 +3108,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605742200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17782.91,
       (string) (len=4) "high": (float64) 17872.99,
@@ -2881,6 +3121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605744000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17675.45,
       (string) (len=4) "high": (float64) 17817.15,
@@ -2893,6 +3134,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605745800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17774.33,
       (string) (len=4) "high": (float64) 17830.72,
@@ -2905,6 +3147,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605747600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17736.69,
       (string) (len=4) "high": (float64) 17779.38,
@@ -2917,6 +3160,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605749400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17872.73,
       (string) (len=4) "high": (float64) 17883.51,
@@ -2929,6 +3173,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605751200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18052.4,
       (string) (len=4) "high": (float64) 18075.5,
@@ -2941,6 +3186,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605753000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17945.69,
       (string) (len=4) "high": (float64) 18053.67,
@@ -2953,6 +3199,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605754800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17949.6,
       (string) (len=4) "high": (float64) 18015.41,
@@ -2965,6 +3212,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605756600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17935.44,
       (string) (len=4) "high": (float64) 17950,
@@ -2977,6 +3225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605758400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17793.46,
       (string) (len=4) "high": (float64) 17938.81,
@@ -2989,6 +3238,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605760200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17871.04,
       (string) (len=4) "high": (float64) 17884.29,
@@ -3001,6 +3251,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605762000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17829.17,
       (string) (len=4) "high": (float64) 17871.03,
@@ -3013,6 +3264,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605763800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17912.24,
       (string) (len=4) "high": (float64) 17924.82,
@@ -3025,6 +3277,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605765600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17788.94,
       (string) (len=4) "high": (float64) 17922.04,
@@ -3037,6 +3290,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605767400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17765.37,
       (string) (len=4) "high": (float64) 17809.06,
@@ -3049,6 +3303,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605769200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17749.02,
       (string) (len=4) "high": (float64) 17781.17,
@@ -3061,6 +3316,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605771000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17669.7,
       (string) (len=4) "high": (float64) 17768.78,
@@ -3073,6 +3329,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605772800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17576.8,
       (string) (len=4) "high": (float64) 17739.9,
@@ -3085,6 +3342,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605774600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17544.95,
       (string) (len=4) "high": (float64) 17644.9,
@@ -3097,6 +3355,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605776400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17598.16,
       (string) (len=4) "high": (float64) 17643.68,
@@ -3109,6 +3368,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605778200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17439.8,
       (string) (len=4) "high": (float64) 17623.01,
@@ -3121,6 +3381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605780000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17475.86,
       (string) (len=4) "high": (float64) 17516.35,
@@ -3133,6 +3394,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605781800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17624,
       (string) (len=4) "high": (float64) 17656.11,
@@ -3145,6 +3407,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605783600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17617.31,
       (string) (len=4) "high": (float64) 17772.01,
@@ -3157,6 +3420,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605785400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17770.49,
       (string) (len=4) "high": (float64) 17775,
@@ -3169,6 +3433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605787200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17709.38,
       (string) (len=4) "high": (float64) 17817.84,
@@ -3181,6 +3446,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605789000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17720.42,
       (string) (len=4) "high": (float64) 17803.32,
@@ -3193,6 +3459,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605790800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17968.27,
       (string) (len=4) "high": (float64) 17978.71,
@@ -3205,6 +3472,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605792600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18010.66,
       (string) (len=4) "high": (float64) 18025.63,
@@ -3217,6 +3485,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605794400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17925.31,
       (string) (len=4) "high": (float64) 18047.99,
@@ -3229,6 +3498,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605796200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18133.01,
       (string) (len=4) "high": (float64) 18158.93,
@@ -3241,6 +3511,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605798000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18111.51,
       (string) (len=4) "high": (float64) 18193.29,
@@ -3253,6 +3524,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605799800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18064.84,
       (string) (len=4) "high": (float64) 18139.07,
@@ -3265,6 +3537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605801600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17978.47,
       (string) (len=4) "high": (float64) 18135,
@@ -3277,6 +3550,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605803400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18020.57,
       (string) (len=4) "high": (float64) 18063.6,
@@ -3289,6 +3563,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605805200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17965.67,
       (string) (len=4) "high": (float64) 18054.88,
@@ -3301,6 +3576,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605807000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17982.2,
       (string) (len=4) "high": (float64) 18028.52,
@@ -3313,6 +3589,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605808800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18008.41,
       (string) (len=4) "high": (float64) 18046.92,
@@ -3325,6 +3602,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605810600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17953.3,
       (string) (len=4) "high": (float64) 18039.17,
@@ -3337,6 +3615,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605812400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17924.32,
       (string) (len=4) "high": (float64) 17979.73,
@@ -3349,6 +3628,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605814200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17979.02,
       (string) (len=4) "high": (float64) 17990,
@@ -3361,6 +3641,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605816000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18005.57,
       (string) (len=4) "high": (float64) 18018.41,
@@ -3373,6 +3654,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605817800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18046.37,
       (string) (len=4) "high": (float64) 18057.29,
@@ -3385,6 +3667,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605819600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18056.09,
       (string) (len=4) "high": (float64) 18110.05,
@@ -3397,6 +3680,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605821400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17950.99,
       (string) (len=4) "high": (float64) 18062.28,
@@ -3409,6 +3693,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605823200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17910.45,
       (string) (len=4) "high": (float64) 17975,
@@ -3421,6 +3706,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605825000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17881,
       (string) (len=4) "high": (float64) 17971.22,
@@ -3433,6 +3719,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605826800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17780.13,
       (string) (len=4) "high": (float64) 17909.85,
@@ -3445,6 +3732,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605828600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17821.58,
       (string) (len=4) "high": (float64) 17860.63,
@@ -3457,6 +3745,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605830400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17885.77,
       (string) (len=4) "high": (float64) 17954.96,
@@ -3469,6 +3758,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605832200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17794.33,
       (string) (len=4) "high": (float64) 17889.94,
@@ -3481,6 +3771,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605834000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17894.91,
       (string) (len=4) "high": (float64) 17898.71,
@@ -3493,6 +3784,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605835800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17976.51,
       (string) (len=4) "high": (float64) 17984.85,
@@ -3505,6 +3797,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605837600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18044.81,
       (string) (len=4) "high": (float64) 18047.88,
@@ -3517,6 +3810,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605839400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17976.35,
       (string) (len=4) "high": (float64) 18058.24,
@@ -3529,6 +3823,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605841200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18006.92,
       (string) (len=4) "high": (float64) 18036.29,
@@ -3541,6 +3836,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605843000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17961.26,
       (string) (len=4) "high": (float64) 18025,
@@ -3553,6 +3849,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605844800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18090.82,
       (string) (len=4) "high": (float64) 18099,
@@ -3565,6 +3862,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605846600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18202.06,
       (string) (len=4) "high": (float64) 18239,
@@ -3577,6 +3875,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605848400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18099.03,
       (string) (len=4) "high": (float64) 18228.98,
@@ -3589,6 +3888,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605850200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18142,
       (string) (len=4) "high": (float64) 18186.64,
@@ -3601,6 +3901,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605852000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18097.65,
       (string) (len=4) "high": (float64) 18190.9,
@@ -3613,6 +3914,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605853800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18174.46,
       (string) (len=4) "high": (float64) 18177.97,
@@ -3625,6 +3927,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605855600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18198.76,
       (string) (len=4) "high": (float64) 18421.63,
@@ -3637,6 +3940,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605857400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18222.21,
       (string) (len=4) "high": (float64) 18241.77,
@@ -3649,6 +3953,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605859200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18286.74,
       (string) (len=4) "high": (float64) 18340.99,
@@ -3661,6 +3966,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605861000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18320.01,
       (string) (len=4) "high": (float64) 18342.73,
@@ -3673,6 +3979,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605862800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18286.22,
       (string) (len=4) "high": (float64) 18389.03,
@@ -3685,6 +3992,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605864600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18200.79,
       (string) (len=4) "high": (float64) 18286.7,
@@ -3697,6 +4005,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605866400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18244.66,
       (string) (len=4) "high": (float64) 18249.42,
@@ -3709,6 +4018,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605868200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18310.36,
       (string) (len=4) "high": (float64) 18349,
@@ -3721,6 +4031,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605870000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18320.35,
       (string) (len=4) "high": (float64) 18370.35,
@@ -3733,6 +4044,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605871800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18287.73,
       (string) (len=4) "high": (float64) 18347.22,
@@ -3745,6 +4057,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605873600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18272.94,
       (string) (len=4) "high": (float64) 18313.68,
@@ -3757,6 +4070,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605875400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18245.93,
       (string) (len=4) "high": (float64) 18309.95,
@@ -3769,6 +4083,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605877200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18180.01,
       (string) (len=4) "high": (float64) 18264.95,
@@ -3781,6 +4096,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605879000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18259.54,
       (string) (len=4) "high": (float64) 18306.23,
@@ -3793,6 +4109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605880800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18370.79,
       (string) (len=4) "high": (float64) 18398.94,
@@ -3805,6 +4122,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605882600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18656.45,
       (string) (len=4) "high": (float64) 18656.45,
@@ -3817,6 +4135,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605884400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18698.01,
       (string) (len=4) "high": (float64) 18756,
@@ -3829,6 +4148,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605886200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18692.32,
       (string) (len=4) "high": (float64) 18762.32,
@@ -3841,6 +4161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605888000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18793.62,
       (string) (len=4) "high": (float64) 18830.3,
@@ -3853,6 +4174,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605889800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18707.07,
       (string) (len=4) "high": (float64) 18808.48,
@@ -3865,6 +4187,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605891600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18681.51,
       (string) (len=4) "high": (float64) 18712.43,
@@ -3877,6 +4200,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605893400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18711.49,
       (string) (len=4) "high": (float64) 18724.58,
@@ -3889,6 +4213,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605895200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18568.72,
       (string) (len=4) "high": (float64) 18713.8,
@@ -3901,6 +4226,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605897000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18593.08,
       (string) (len=4) "high": (float64) 18613.03,
@@ -3913,6 +4239,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605898800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18653.16,
       (string) (len=4) "high": (float64) 18657.27,
@@ -3925,6 +4252,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605900600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18640,
       (string) (len=4) "high": (float64) 18684.24,
@@ -3937,6 +4265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605902400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18601.71,
       (string) (len=4) "high": (float64) 18702,
@@ -3949,6 +4278,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605904200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18650.58,
       (string) (len=4) "high": (float64) 18709.99,
@@ -3961,6 +4291,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605906000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18579.19,
       (string) (len=4) "high": (float64) 18671.79,
@@ -3973,6 +4304,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605907800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18599.58,
       (string) (len=4) "high": (float64) 18656.02,
@@ -3985,6 +4317,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605909600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18556.04,
       (string) (len=4) "high": (float64) 18624.78,
@@ -3997,6 +4330,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605911400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18640.35,
       (string) (len=4) "high": (float64) 18648.84,
@@ -4009,6 +4343,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605913200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18663.92,
       (string) (len=4) "high": (float64) 18767,
@@ -4021,6 +4356,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605915000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18675.25,
       (string) (len=4) "high": (float64) 18695.18,
@@ -4033,6 +4369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605916800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18767.11,
       (string) (len=4) "high": (float64) 18771.8,
@@ -4045,6 +4382,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605918600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18886.39,
       (string) (len=4) "high": (float64) 18887.72,
@@ -4057,6 +4395,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605920400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18910.65,
       (string) (len=4) "high": (float64) 18925,
@@ -4069,6 +4408,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605922200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18850,
       (string) (len=4) "high": (float64) 18918.03,
@@ -4081,6 +4421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605924000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18969.9,
       (string) (len=4) "high": (float64) 18980,
@@ -4093,6 +4434,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605925800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18762.54,
       (string) (len=4) "high": (float64) 18969.91,
@@ -4105,6 +4447,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605927600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18806.83,
       (string) (len=4) "high": (float64) 18835.01,
@@ -4117,6 +4460,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605929400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18676.49,
       (string) (len=4) "high": (float64) 18841.31,
@@ -4129,6 +4473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605931200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18598.76,
       (string) (len=4) "high": (float64) 18683.12,
@@ -4141,6 +4486,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605933000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18599.89,
       (string) (len=4) "high": (float64) 18645.75,
@@ -4153,6 +4499,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605934800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18647.18,
       (string) (len=4) "high": (float64) 18681.27,
@@ -4165,6 +4512,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605936600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18672.97,
       (string) (len=4) "high": (float64) 18692.84,
@@ -4177,6 +4525,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605938400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18713.61,
       (string) (len=4) "high": (float64) 18748.98,
@@ -4189,6 +4538,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605940200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18653.66,
       (string) (len=4) "high": (float64) 18719.57,
@@ -4201,6 +4551,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605942000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18744.42,
       (string) (len=4) "high": (float64) 18750,
@@ -4213,6 +4564,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605943800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18682.64,
       (string) (len=4) "high": (float64) 18754.63,
@@ -4225,6 +4577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605945600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18782.69,
       (string) (len=4) "high": (float64) 18782.74,
@@ -4237,6 +4590,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605947400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18807.99,
       (string) (len=4) "high": (float64) 18808.02,
@@ -4249,6 +4603,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605949200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18702.87,
       (string) (len=4) "high": (float64) 18808,
@@ -4261,6 +4616,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605951000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18633.42,
       (string) (len=4) "high": (float64) 18702.37,
@@ -4273,6 +4629,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605952800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18702.2,
       (string) (len=4) "high": (float64) 18728.85,
@@ -4285,6 +4642,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605954600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18611.57,
       (string) (len=4) "high": (float64) 18712.33,
@@ -4297,6 +4655,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605956400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18565.69,
       (string) (len=4) "high": (float64) 18671.52,
@@ -4309,6 +4668,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605958200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18550.01,
       (string) (len=4) "high": (float64) 18604.95,
@@ -4321,6 +4681,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605960000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18694.09,
       (string) (len=4) "high": (float64) 18720,
@@ -4333,6 +4694,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605961800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18656.82,
       (string) (len=4) "high": (float64) 18700,
@@ -4345,6 +4707,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605963600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18733.39,
       (string) (len=4) "high": (float64) 18735.38,
@@ -4357,6 +4720,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605965400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18812.52,
       (string) (len=4) "high": (float64) 18849,
@@ -4369,6 +4733,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605967200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18705.04,
       (string) (len=4) "high": (float64) 18822.72,
@@ -4381,6 +4746,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605969000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18756.04,
       (string) (len=4) "high": (float64) 18798.94,
@@ -4393,6 +4759,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605970800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18812.72,
       (string) (len=4) "high": (float64) 18845,
@@ -4405,6 +4772,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605972600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18818.15,
       (string) (len=4) "high": (float64) 18832.98,
@@ -4417,6 +4785,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605974400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18869.26,
       (string) (len=4) "high": (float64) 18924.47,
@@ -4429,6 +4798,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605976200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18768.77,
       (string) (len=4) "high": (float64) 18933.3,
@@ -4441,6 +4811,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605978000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18740.05,
       (string) (len=4) "high": (float64) 18804.35,
@@ -4453,6 +4824,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605979800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18772.96,
       (string) (len=4) "high": (float64) 18791.21,
@@ -4465,6 +4837,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605981600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18759.99,
       (string) (len=4) "high": (float64) 18811.71,
@@ -4477,6 +4850,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605983400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18762.62,
       (string) (len=4) "high": (float64) 18818.34,
@@ -4489,6 +4863,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605985200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18675.77,
       (string) (len=4) "high": (float64) 18795.02,
@@ -4501,6 +4876,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605987000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18697.95,
       (string) (len=4) "high": (float64) 18727.77,
@@ -4513,6 +4889,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605988800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18661.67,
       (string) (len=4) "high": (float64) 18698.16,
@@ -4525,6 +4902,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605990600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18669.35,
       (string) (len=4) "high": (float64) 18694.2,
@@ -4537,6 +4915,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605992400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18627.96,
       (string) (len=4) "high": (float64) 18674.58,
@@ -4549,6 +4928,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605994200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18670.94,
       (string) (len=4) "high": (float64) 18713.54,
@@ -4561,6 +4941,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605996000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18599.56,
       (string) (len=4) "high": (float64) 18674.06,
@@ -4573,6 +4954,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605997800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18648.07,
       (string) (len=4) "high": (float64) 18660.6,
@@ -4585,6 +4967,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605999600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18693.06,
       (string) (len=4) "high": (float64) 18694.4,
@@ -4597,6 +4980,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606001400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18721.21,
       (string) (len=4) "high": (float64) 18767.03,
@@ -4609,6 +4993,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606003200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18700.03,
       (string) (len=4) "high": (float64) 18773.56,
@@ -4621,6 +5006,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606005000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18556.81,
       (string) (len=4) "high": (float64) 18721.58,
@@ -4633,6 +5019,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606006800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18535.76,
       (string) (len=4) "high": (float64) 18622.16,
@@ -4645,6 +5032,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606008600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18473.48,
       (string) (len=4) "high": (float64) 18536.7,
@@ -4657,6 +5045,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606010400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18503.93,
       (string) (len=4) "high": (float64) 18529.66,
@@ -4669,6 +5058,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606012200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18601.52,
       (string) (len=4) "high": (float64) 18622.38,
@@ -4681,6 +5071,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606014000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18498.98,
       (string) (len=4) "high": (float64) 18608.71,
@@ -4693,6 +5084,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606015800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18574.3,
       (string) (len=4) "high": (float64) 18589.29,
@@ -4705,6 +5097,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606017600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18529.2,
       (string) (len=4) "high": (float64) 18592.08,
@@ -4717,6 +5110,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606019400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18608.67,
       (string) (len=4) "high": (float64) 18617.96,
@@ -4729,6 +5123,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606021200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18564.39,
       (string) (len=4) "high": (float64) 18608.67,
@@ -4741,6 +5136,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606023000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18526.4,
       (string) (len=4) "high": (float64) 18562.59,
@@ -4753,6 +5149,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606024800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18464.02,
       (string) (len=4) "high": (float64) 18598.94,
@@ -4765,6 +5162,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606026600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18490.83,
       (string) (len=4) "high": (float64) 18523.37,
@@ -4777,6 +5175,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606028400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18359.01,
       (string) (len=4) "high": (float64) 18490.83,
@@ -4789,6 +5188,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606030200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18517.26,
       (string) (len=4) "high": (float64) 18527.51,
@@ -4801,6 +5201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606032000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18381.56,
       (string) (len=4) "high": (float64) 18516.67,
@@ -4813,6 +5214,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606033800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18219.49,
       (string) (len=4) "high": (float64) 18410.85,
@@ -4825,6 +5227,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606035600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18269.71,
       (string) (len=4) "high": (float64) 18358.77,
@@ -4837,6 +5240,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606037400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18379.44,
       (string) (len=4) "high": (float64) 18428.14,
@@ -4849,6 +5253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606039200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18261.28,
       (string) (len=4) "high": (float64) 18374.75,
@@ -4861,6 +5266,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606041000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18177.86,
       (string) (len=4) "high": (float64) 18258.68,
@@ -4873,6 +5279,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606042800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17969.61,
       (string) (len=4) "high": (float64) 18211.02,
@@ -4885,6 +5292,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606044600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17891.13,
       (string) (len=4) "high": (float64) 18014.59,
@@ -4897,6 +5305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606046400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18067.87,
       (string) (len=4) "high": (float64) 18130.22,
@@ -4909,6 +5318,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606048200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18122.58,
       (string) (len=4) "high": (float64) 18161.51,
@@ -4921,6 +5331,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606050000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18244.02,
       (string) (len=4) "high": (float64) 18246.26,
@@ -4933,6 +5344,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606051800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18213.22,
       (string) (len=4) "high": (float64) 18252.37,
@@ -4945,6 +5357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606053600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18255.33,
       (string) (len=4) "high": (float64) 18301.92,
@@ -4957,6 +5370,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606055400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18195.03,
       (string) (len=4) "high": (float64) 18300,
@@ -4969,6 +5383,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606057200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18240.64,
       (string) (len=4) "high": (float64) 18275.79,
@@ -4981,6 +5396,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606059000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18312.17,
       (string) (len=4) "high": (float64) 18345.18,
@@ -4993,6 +5409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606060800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18453.41,
       (string) (len=4) "high": (float64) 18466,
@@ -5005,6 +5422,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606062600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18566.41,
       (string) (len=4) "high": (float64) 18600,
@@ -5017,6 +5435,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606064400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18556.68,
       (string) (len=4) "high": (float64) 18595.2,
@@ -5029,6 +5448,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606066200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18494.57,
       (string) (len=4) "high": (float64) 18557.61,
@@ -5041,6 +5461,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606068000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18548.24,
       (string) (len=4) "high": (float64) 18641.01,
@@ -5053,6 +5474,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606069800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18522.62,
       (string) (len=4) "high": (float64) 18609.14,
@@ -5065,6 +5487,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606071600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18522.91,
       (string) (len=4) "high": (float64) 18589.71,
@@ -5077,6 +5500,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606073400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18591.38,
       (string) (len=4) "high": (float64) 18615,
@@ -5089,6 +5513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606075200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18637.74,
       (string) (len=4) "high": (float64) 18700,
@@ -5101,6 +5526,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606077000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18576.61,
       (string) (len=4) "high": (float64) 18648.69,
@@ -5113,6 +5539,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606078800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18626.64,
       (string) (len=4) "high": (float64) 18631,
@@ -5125,6 +5552,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606080600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18600.6,
       (string) (len=4) "high": (float64) 18644.05,
@@ -5137,6 +5565,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606082400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18653.26,
       (string) (len=4) "high": (float64) 18666.66,
@@ -5149,6 +5578,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606084200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18643.16,
       (string) (len=4) "high": (float64) 18680.85,
@@ -5161,6 +5591,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606086000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18509.64,
       (string) (len=4) "high": (float64) 18650,
@@ -5173,6 +5604,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606087800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18437.66,
       (string) (len=4) "high": (float64) 18558.37,
@@ -5185,6 +5617,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606089600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18271.42,
       (string) (len=4) "high": (float64) 18529,
@@ -5197,6 +5630,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606091400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18140,
       (string) (len=4) "high": (float64) 18343.93,
@@ -5209,6 +5643,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606093200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18110.38,
       (string) (len=4) "high": (float64) 18281.31,
@@ -5221,6 +5656,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606095000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18230,
       (string) (len=4) "high": (float64) 18275,
@@ -5233,6 +5669,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606096800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18258.29,
       (string) (len=4) "high": (float64) 18360.86,
@@ -5245,6 +5682,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606098600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18230.78,
       (string) (len=4) "high": (float64) 18318.73,
@@ -5257,6 +5695,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606100400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18402.5,
       (string) (len=4) "high": (float64) 18409.2,
@@ -5269,6 +5708,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606102200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18378.53,
       (string) (len=4) "high": (float64) 18459.57,
@@ -5281,6 +5721,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606104000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18479.32,
       (string) (len=4) "high": (float64) 18534.8,
@@ -5293,6 +5734,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606105800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18480,
       (string) (len=4) "high": (float64) 18533.38,
@@ -5305,6 +5747,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606107600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18511.49,
       (string) (len=4) "high": (float64) 18524.11,
@@ -5317,6 +5760,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606109400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18462.33,
       (string) (len=4) "high": (float64) 18522.52,
@@ -5329,6 +5773,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606111200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18343.13,
       (string) (len=4) "high": (float64) 18471.3,
@@ -5341,6 +5786,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606113000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18543.84,
       (string) (len=4) "high": (float64) 18544.26,
@@ -5353,6 +5799,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606114800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18490.6,
       (string) (len=4) "high": (float64) 18577.46,
@@ -5365,6 +5812,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606116600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18468.78,
       (string) (len=4) "high": (float64) 18517.17,
@@ -5377,6 +5825,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606118400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18639.99,
       (string) (len=4) "high": (float64) 18649,
@@ -5389,6 +5838,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606120200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18588.09,
       (string) (len=4) "high": (float64) 18671.45,
@@ -5401,6 +5851,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606122000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18580.05,
       (string) (len=4) "high": (float64) 18634.74,
@@ -5413,6 +5864,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606123800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18665.14,
       (string) (len=4) "high": (float64) 18676.81,
@@ -5425,6 +5877,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606125600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18752.97,
       (string) (len=4) "high": (float64) 18755,
@@ -5437,6 +5890,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606127400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18767.21,
       (string) (len=4) "high": (float64) 18777.77,
@@ -5449,6 +5903,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606129200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18633.55,
       (string) (len=4) "high": (float64) 18769.85,
@@ -5461,6 +5916,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606131000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18585.01,
       (string) (len=4) "high": (float64) 18688.08,
@@ -5473,6 +5929,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606132800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18557.96,
       (string) (len=4) "high": (float64) 18642.9,
@@ -5485,6 +5942,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606134600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18637.96,
       (string) (len=4) "high": (float64) 18658.87,
@@ -5497,6 +5955,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606136400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18422.43,
       (string) (len=4) "high": (float64) 18683.14,
@@ -5509,6 +5968,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606138200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18622.69,
       (string) (len=4) "high": (float64) 18624.61,
@@ -5521,6 +5981,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606140000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18581.42,
       (string) (len=4) "high": (float64) 18719.99,
@@ -5533,6 +5994,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606141800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18559.08,
       (string) (len=4) "high": (float64) 18669.21,
@@ -5545,6 +6007,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606143600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18385.87,
       (string) (len=4) "high": (float64) 18578.94,
@@ -5557,6 +6020,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606145400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18281.63,
       (string) (len=4) "high": (float64) 18425.83,
@@ -5569,6 +6033,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606147200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18350.21,
       (string) (len=4) "high": (float64) 18392.19,
@@ -5581,6 +6046,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606149000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18398.05,
       (string) (len=4) "high": (float64) 18425,
@@ -5593,6 +6059,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606150800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18435.31,
       (string) (len=4) "high": (float64) 18439.73,
@@ -5605,6 +6072,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606152600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18358.71,
       (string) (len=4) "high": (float64) 18482.35,
@@ -5617,6 +6085,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606154400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18340.96,
       (string) (len=4) "high": (float64) 18377.93,
@@ -5629,6 +6098,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606156200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18357.92,
       (string) (len=4) "high": (float64) 18439.66,
@@ -5641,6 +6111,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606158000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18387.13,
       (string) (len=4) "high": (float64) 18397.83,
@@ -5653,6 +6124,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606159800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18459.89,
       (string) (len=4) "high": (float64) 18479.59,
@@ -5665,6 +6137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606161600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18408.35,
       (string) (len=4) "high": (float64) 18499.94,
@@ -5677,6 +6150,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606163400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18397.54,
       (string) (len=4) "high": (float64) 18421.91,
@@ -5689,6 +6163,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606165200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18412.85,
       (string) (len=4) "high": (float64) 18434.69,
@@ -5701,6 +6176,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606167000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18422.02,
       (string) (len=4) "high": (float64) 18473.09,
@@ -5713,6 +6189,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606168800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18397.91,
       (string) (len=4) "high": (float64) 18443.18,
@@ -5725,6 +6202,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606170600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18435.56,
       (string) (len=4) "high": (float64) 18489.56,
@@ -5737,6 +6215,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606172400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18412.51,
       (string) (len=4) "high": (float64) 18457.39,
@@ -5749,6 +6228,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606174200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18384.82,
       (string) (len=4) "high": (float64) 18418.03,
@@ -5761,6 +6241,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606176000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18238.58,
       (string) (len=4) "high": (float64) 18391.21,
@@ -5773,6 +6254,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606177800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18375.7,
       (string) (len=4) "high": (float64) 18380.32,
@@ -5785,6 +6267,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606179600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18533.13,
       (string) (len=4) "high": (float64) 18550,
@@ -5797,6 +6280,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606181400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18485.11,
       (string) (len=4) "high": (float64) 18541.96,
@@ -5809,6 +6293,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606183200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18436.39,
       (string) (len=4) "high": (float64) 18499.94,
@@ -5821,6 +6306,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606185000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18360,
       (string) (len=4) "high": (float64) 18462.2,
@@ -5833,6 +6319,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606186800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18400,
       (string) (len=4) "high": (float64) 18424.58,
@@ -5845,6 +6332,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606188600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18367.39,
       (string) (len=4) "high": (float64) 18423.5,
@@ -5857,6 +6345,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606190400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18355.21,
       (string) (len=4) "high": (float64) 18400.03,
@@ -5869,6 +6358,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606192200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18462.67,
       (string) (len=4) "high": (float64) 18466.82,
@@ -5881,6 +6371,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606194000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18373.52,
       (string) (len=4) "high": (float64) 18462.67,
@@ -5893,6 +6384,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606195800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18350.13,
       (string) (len=4) "high": (float64) 18442.42,
@@ -5905,6 +6397,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606197600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18349.98,
       (string) (len=4) "high": (float64) 18350.78,
@@ -5917,6 +6410,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606199400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18413.67,
       (string) (len=4) "high": (float64) 18414.85,
@@ -5929,6 +6423,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606201200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18447.28,
       (string) (len=4) "high": (float64) 18462.75,
@@ -5941,6 +6436,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606203000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18392.39,
       (string) (len=4) "high": (float64) 18468.2,
@@ -5953,6 +6449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606204800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18477.57,
       (string) (len=4) "high": (float64) 18510.13,
@@ -5965,6 +6462,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606206600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18638.75,
       (string) (len=4) "high": (float64) 18640.93,
@@ -5977,6 +6475,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606208400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18889.13,
       (string) (len=4) "high": (float64) 18897.99,
@@ -5989,6 +6488,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606210200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18982.53,
       (string) (len=4) "high": (float64) 19040,
@@ -6001,6 +6501,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606212000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18767.77,
       (string) (len=4) "high": (float64) 19100,
@@ -6013,6 +6514,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606213800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18896.6,
       (string) (len=4) "high": (float64) 18963.29,
@@ -6025,6 +6527,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606215600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18939.93,
       (string) (len=4) "high": (float64) 19052,
@@ -6037,6 +6540,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606217400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19077,
       (string) (len=4) "high": (float64) 19080,
@@ -6049,6 +6553,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606219200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19140.92,
       (string) (len=4) "high": (float64) 19197.96,
@@ -6061,6 +6566,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606221000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19195.8,
       (string) (len=4) "high": (float64) 19266.84,
@@ -6073,6 +6579,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606222800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19269.34,
       (string) (len=4) "high": (float64) 19332.95,
@@ -6085,6 +6592,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606224600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19205.04,
       (string) (len=4) "high": (float64) 19330.72,
@@ -6097,6 +6605,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606226400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19281.33,
       (string) (len=4) "high": (float64) 19289.77,
@@ -6109,6 +6618,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606228200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19419.99,
       (string) (len=4) "high": (float64) 19420,
@@ -6121,6 +6631,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606230000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19350.28,
       (string) (len=4) "high": (float64) 19447,
@@ -6133,6 +6644,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606231800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19392.68,
       (string) (len=4) "high": (float64) 19450,
@@ -6145,6 +6657,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606233600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19240.37,
       (string) (len=4) "high": (float64) 19469,
@@ -6157,6 +6670,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606235400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19312.78,
       (string) (len=4) "high": (float64) 19339.92,
@@ -6169,6 +6683,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606237200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19232.16,
       (string) (len=4) "high": (float64) 19367.69,
@@ -6181,6 +6696,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606239000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19214.7,
       (string) (len=4) "high": (float64) 19318.85,
@@ -6193,6 +6709,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606240800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19199.52,
       (string) (len=4) "high": (float64) 19276.47,
@@ -6205,6 +6722,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606242600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19276.07,
       (string) (len=4) "high": (float64) 19285.01,
@@ -6217,6 +6735,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606244400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19285,
       (string) (len=4) "high": (float64) 19300,
@@ -6229,6 +6748,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606246200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19168.01,
       (string) (len=4) "high": (float64) 19291.67,
@@ -6241,6 +6761,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606248000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19094.16,
       (string) (len=4) "high": (float64) 19250,
@@ -6253,6 +6774,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606249800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19069.62,
       (string) (len=4) "high": (float64) 19110.16,
@@ -6265,6 +6787,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606251600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19030,
       (string) (len=4) "high": (float64) 19189,
@@ -6277,6 +6800,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606253400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18944.42,
       (string) (len=4) "high": (float64) 19073.93,
@@ -6289,6 +6813,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606255200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19056.53,
       (string) (len=4) "high": (float64) 19085.19,
@@ -6301,6 +6826,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606257000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19140.01,
       (string) (len=4) "high": (float64) 19147.59,
@@ -6313,6 +6839,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606258800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19142.01,
       (string) (len=4) "high": (float64) 19205,
@@ -6325,6 +6852,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606260600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19172.84,
       (string) (len=4) "high": (float64) 19203.97,
@@ -6337,6 +6865,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606262400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19161.78,
       (string) (len=4) "high": (float64) 19234.71,
@@ -6349,6 +6878,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606264200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19180.87,
       (string) (len=4) "high": (float64) 19240.34,
@@ -6361,6 +6891,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606266000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19185,
       (string) (len=4) "high": (float64) 19225,
@@ -6373,6 +6904,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606267800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19100.99,
       (string) (len=4) "high": (float64) 19185,
@@ -6385,6 +6917,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606269600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19010,
       (string) (len=4) "high": (float64) 19102.89,
@@ -6397,6 +6930,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606271400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18985.13,
       (string) (len=4) "high": (float64) 19058.4,
@@ -6409,6 +6943,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606273200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19048.23,
       (string) (len=4) "high": (float64) 19049.47,
@@ -6421,6 +6956,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606275000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18826.13,
       (string) (len=4) "high": (float64) 19048.23,
@@ -6433,6 +6969,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606276800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18900.29,
       (string) (len=4) "high": (float64) 18918.48,
@@ -6445,6 +6982,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606278600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18699.71,
       (string) (len=4) "high": (float64) 18931.66,
@@ -6457,6 +6995,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606280400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18825.07,
       (string) (len=4) "high": (float64) 18832.52,
@@ -6469,6 +7008,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606282200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18894.91,
       (string) (len=4) "high": (float64) 18903.68,
@@ -6481,6 +7021,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606284000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18925.01,
       (string) (len=4) "high": (float64) 18960.54,
@@ -6493,6 +7034,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606285800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18912.17,
       (string) (len=4) "high": (float64) 18939.16,
@@ -6505,6 +7047,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606287600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19007.91,
       (string) (len=4) "high": (float64) 19038.97,
@@ -6517,6 +7060,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606289400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18992.58,
       (string) (len=4) "high": (float64) 19070,
@@ -6529,6 +7073,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606291200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19190.5,
       (string) (len=4) "high": (float64) 19200,
@@ -6541,6 +7086,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606293000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19133.4,
       (string) (len=4) "high": (float64) 19241.19,
@@ -6553,6 +7099,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606294800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19144.96,
       (string) (len=4) "high": (float64) 19166.89,
@@ -6565,6 +7112,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606296600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19167.51,
       (string) (len=4) "high": (float64) 19167.51,
@@ -6577,6 +7125,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606298400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19358.13,
       (string) (len=4) "high": (float64) 19360,
@@ -6589,6 +7138,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606300200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19307.91,
       (string) (len=4) "high": (float64) 19358.26,
@@ -6601,6 +7151,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606302000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19313.81,
       (string) (len=4) "high": (float64) 19357.53,
@@ -6613,6 +7164,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606303800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19299.62,
       (string) (len=4) "high": (float64) 19359.96,
@@ -6625,6 +7177,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606305600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19254.75,
       (string) (len=4) "high": (float64) 19326.87,
@@ -6637,6 +7190,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606307400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19329.06,
       (string) (len=4) "high": (float64) 19342.85,
@@ -6649,6 +7203,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606309200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19263.07,
       (string) (len=4) "high": (float64) 19335.46,
@@ -6661,6 +7216,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606311000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19216.27,
       (string) (len=4) "high": (float64) 19500,
@@ -6673,6 +7229,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606312800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19165,
       (string) (len=4) "high": (float64) 19323.76,
@@ -6685,6 +7242,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606314600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19298.21,
       (string) (len=4) "high": (float64) 19309.68,
@@ -6697,6 +7255,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606316400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19323.56,
       (string) (len=4) "high": (float64) 19337.02,
@@ -6709,6 +7268,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606318200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19140.04,
       (string) (len=4) "high": (float64) 19350,
@@ -6721,6 +7281,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606320000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19019.66,
       (string) (len=4) "high": (float64) 19216.06,
@@ -6733,6 +7294,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606321800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18995.84,
       (string) (len=4) "high": (float64) 19063.1,
@@ -6745,6 +7307,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606323600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18909.58,
       (string) (len=4) "high": (float64) 19049.35,
@@ -6757,6 +7320,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606325400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19073.75,
       (string) (len=4) "high": (float64) 19077.44,
@@ -6769,6 +7333,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606327200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19121.69,
       (string) (len=4) "high": (float64) 19131.74,
@@ -6781,6 +7346,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606329000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19061.81,
       (string) (len=4) "high": (float64) 19145.88,
@@ -6793,6 +7359,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606330800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19012.3,
       (string) (len=4) "high": (float64) 19137.12,
@@ -6805,6 +7372,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606332600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18990.56,
       (string) (len=4) "high": (float64) 19030.99,
@@ -6817,6 +7385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606334400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18913.38,
       (string) (len=4) "high": (float64) 19099.99,
@@ -6829,6 +7398,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606336200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18910,
       (string) (len=4) "high": (float64) 18924.08,
@@ -6841,6 +7411,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606338000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18981.12,
       (string) (len=4) "high": (float64) 19037.22,
@@ -6853,6 +7424,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606339800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18881.52,
       (string) (len=4) "high": (float64) 19038.18,
@@ -6865,6 +7437,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606341600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18823.12,
       (string) (len=4) "high": (float64) 18927,
@@ -6877,6 +7450,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606343400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18766.58,
       (string) (len=4) "high": (float64) 18833.26,
@@ -6889,6 +7463,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606345200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18731.54,
       (string) (len=4) "high": (float64) 18761.48,
@@ -6901,6 +7476,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606347000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18721.93,
       (string) (len=4) "high": (float64) 18858.65,
@@ -6913,6 +7489,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606348800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18865.64,
       (string) (len=4) "high": (float64) 18870.63,
@@ -6925,6 +7502,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606350600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18869.59,
       (string) (len=4) "high": (float64) 18915.48,
@@ -6937,6 +7515,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606352400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18807.09,
       (string) (len=4) "high": (float64) 18896.98,
@@ -6949,6 +7528,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606354200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18804.06,
       (string) (len=4) "high": (float64) 18850.44,
@@ -6961,6 +7541,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606356000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18550.91,
       (string) (len=4) "high": (float64) 18808.36,
@@ -6973,6 +7554,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606357800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18409.83,
       (string) (len=4) "high": (float64) 18620,
@@ -6985,6 +7567,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606359600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18121.46,
       (string) (len=4) "high": (float64) 18407.68,
@@ -6997,6 +7580,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606361400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17952.19,
       (string) (len=4) "high": (float64) 18121.46,
@@ -7009,6 +7593,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606363200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17855.14,
       (string) (len=4) "high": (float64) 18099.7,
@@ -7021,6 +7606,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606365000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17767.8,
       (string) (len=4) "high": (float64) 17958.79,
@@ -7033,6 +7619,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606366800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17710.56,
       (string) (len=4) "high": (float64) 17941.72,
@@ -7045,6 +7632,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606368600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17929.59,
       (string) (len=4) "high": (float64) 17936.77,
@@ -7057,6 +7645,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606370400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17991.55,
       (string) (len=4) "high": (float64) 18028.02,
@@ -7069,6 +7658,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606372200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17968.09,
       (string) (len=4) "high": (float64) 17999,
@@ -7081,6 +7671,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606374000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17765.17,
       (string) (len=4) "high": (float64) 17967.53,
@@ -7093,6 +7684,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606375800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17589.93,
       (string) (len=4) "high": (float64) 17805.75,
@@ -7105,6 +7697,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606377600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17028.09,
       (string) (len=4) "high": (float64) 17579.98,
@@ -7117,6 +7710,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606379400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16824.73,
       (string) (len=4) "high": (float64) 17028.1,
@@ -7129,6 +7723,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606381200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16734.89,
       (string) (len=4) "high": (float64) 17116.84,
@@ -7141,6 +7736,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606383000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17058.63,
       (string) (len=4) "high": (float64) 17131.07,
@@ -7153,6 +7749,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606384800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17133.51,
       (string) (len=4) "high": (float64) 17316.61,
@@ -7165,6 +7762,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606386600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17294.92,
       (string) (len=4) "high": (float64) 17303.9,
@@ -7177,6 +7775,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606388400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17280.6,
       (string) (len=4) "high": (float64) 17433.81,
@@ -7189,6 +7788,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606390200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17103.74,
       (string) (len=4) "high": (float64) 17355.26,
@@ -7201,6 +7801,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606392000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17332.07,
       (string) (len=4) "high": (float64) 17374.01,
@@ -7213,6 +7814,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606393800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17393.06,
       (string) (len=4) "high": (float64) 17416.69,
@@ -7225,6 +7827,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606395600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17260.7,
       (string) (len=4) "high": (float64) 17418.73,
@@ -7237,6 +7840,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606397400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17064.1,
       (string) (len=4) "high": (float64) 17357.33,
@@ -7249,6 +7853,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606399200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16849.09,
       (string) (len=4) "high": (float64) 17129.86,
@@ -7261,6 +7866,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606401000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16776.49,
       (string) (len=4) "high": (float64) 16960.4,
@@ -7273,6 +7879,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606402800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17164.67,
       (string) (len=4) "high": (float64) 17249.99,
@@ -7285,6 +7892,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606404600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16912.74,
       (string) (len=4) "high": (float64) 17215.51,
@@ -7297,6 +7905,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606406400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16941.93,
       (string) (len=4) "high": (float64) 17045.03,
@@ -7309,6 +7918,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606408200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16669.43,
       (string) (len=4) "high": (float64) 16984.02,
@@ -7321,6 +7931,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606410000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16297.09,
       (string) (len=4) "high": (float64) 16669.46,
@@ -7333,6 +7944,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606411800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16719.86,
       (string) (len=4) "high": (float64) 16749.72,
@@ -7345,6 +7957,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606413600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16684,
       (string) (len=4) "high": (float64) 16818.08,
@@ -7357,6 +7970,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606415400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16550,
       (string) (len=4) "high": (float64) 16848.2,
@@ -7369,6 +7983,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606417200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16370.4,
       (string) (len=4) "high": (float64) 16605.92,
@@ -7381,6 +7996,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606419000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16533.46,
       (string) (len=4) "high": (float64) 16641.88,
@@ -7393,6 +8009,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606420800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16859.93,
       (string) (len=4) "high": (float64) 16970.61,
@@ -7405,6 +8022,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606422600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17179.46,
       (string) (len=4) "high": (float64) 17200,
@@ -7417,6 +8035,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606424400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17138.56,
       (string) (len=4) "high": (float64) 17344.09,
@@ -7429,6 +8048,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606426200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17050.01,
       (string) (len=4) "high": (float64) 17233.7,
@@ -7441,6 +8061,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606428000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17175.11,
       (string) (len=4) "high": (float64) 17181.95,
@@ -7453,6 +8074,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606429800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17192.1,
       (string) (len=4) "high": (float64) 17250.93,
@@ -7465,6 +8087,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606431600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17138.36,
       (string) (len=4) "high": (float64) 17201.12,
@@ -7477,6 +8100,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606433400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17170,
       (string) (len=4) "high": (float64) 17182.09,
@@ -7489,6 +8113,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606435200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17134.99,
       (string) (len=4) "high": (float64) 17199.01,
@@ -7501,6 +8126,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606437000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17408.2,
       (string) (len=4) "high": (float64) 17424,
@@ -7513,6 +8139,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606438800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17368.46,
       (string) (len=4) "high": (float64) 17475,
@@ -7525,6 +8152,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606440600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17327.67,
       (string) (len=4) "high": (float64) 17454.02,
@@ -7537,6 +8165,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606442400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17291.8,
       (string) (len=4) "high": (float64) 17340,
@@ -7549,6 +8178,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606444200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17103.91,
       (string) (len=4) "high": (float64) 17304.07,
@@ -7561,6 +8191,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606446000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17238.16,
       (string) (len=4) "high": (float64) 17280,
@@ -7573,6 +8204,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606447800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17096,
       (string) (len=4) "high": (float64) 17287.69,
@@ -7585,6 +8217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606449600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17157.94,
       (string) (len=4) "high": (float64) 17196.4,
@@ -7597,6 +8230,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606451400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17083.18,
       (string) (len=4) "high": (float64) 17170.43,
@@ -7609,6 +8243,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606453200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17259.14,
       (string) (len=4) "high": (float64) 17313.8,
@@ -7621,6 +8256,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606455000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17272.42,
       (string) (len=4) "high": (float64) 17356.3,
@@ -7633,6 +8269,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606456800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17220.23,
       (string) (len=4) "high": (float64) 17309.15,
@@ -7645,6 +8282,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606458600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17296.87,
       (string) (len=4) "high": (float64) 17323.96,
@@ -7657,6 +8295,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606460400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17141.13,
       (string) (len=4) "high": (float64) 17309.71,
@@ -7669,6 +8308,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606462200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17090.67,
       (string) (len=4) "high": (float64) 17167.72,
@@ -7681,6 +8321,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606464000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16746.46,
       (string) (len=4) "high": (float64) 17108.13,
@@ -7693,6 +8334,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606465800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16843.01,
       (string) (len=4) "high": (float64) 16895.4,
@@ -7705,6 +8347,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606467600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16791.65,
       (string) (len=4) "high": (float64) 17200,
@@ -7717,6 +8360,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606469400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16640.05,
       (string) (len=4) "high": (float64) 16840.7,
@@ -7729,6 +8373,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606471200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16795.26,
       (string) (len=4) "high": (float64) 16879.64,
@@ -7741,6 +8386,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606473000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16905.25,
       (string) (len=4) "high": (float64) 16933.67,
@@ -7753,6 +8399,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606474800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16856.49,
       (string) (len=4) "high": (float64) 16927.9,
@@ -7765,6 +8412,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606476600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16783.86,
       (string) (len=4) "high": (float64) 16852.16,
@@ -7777,6 +8425,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606478400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16893.96,
       (string) (len=4) "high": (float64) 16932.75,
@@ -7789,6 +8438,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606480200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17069.19,
       (string) (len=4) "high": (float64) 17074.38,
@@ -7801,6 +8451,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606482000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17000.01,
       (string) (len=4) "high": (float64) 17077.81,
@@ -7813,6 +8464,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606483800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16942.61,
       (string) (len=4) "high": (float64) 17034.62,
@@ -7825,6 +8477,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606485600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16844.24,
       (string) (len=4) "high": (float64) 16958.2,
@@ -7837,6 +8490,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606487400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16760.51,
       (string) (len=4) "high": (float64) 16944.84,
@@ -7849,6 +8503,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606489200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16664.34,
       (string) (len=4) "high": (float64) 16775.85,
@@ -7861,6 +8516,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606491000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16494.26,
       (string) (len=4) "high": (float64) 16722.7,
@@ -7873,6 +8529,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606492800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16703.38,
       (string) (len=4) "high": (float64) 16762.78,
@@ -7885,6 +8542,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606494600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16823.01,
       (string) (len=4) "high": (float64) 16845.02,
@@ -7897,6 +8555,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606496400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16758.85,
       (string) (len=4) "high": (float64) 16823,
@@ -7909,6 +8568,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606498200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16737.45,
       (string) (len=4) "high": (float64) 16769.01,
@@ -7921,6 +8581,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606500000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16820.01,
       (string) (len=4) "high": (float64) 16870.01,
@@ -7933,6 +8594,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606501800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16790.52,
       (string) (len=4) "high": (float64) 16850,
@@ -7945,6 +8607,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606503600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16763.11,
       (string) (len=4) "high": (float64) 16855,
@@ -7957,6 +8620,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606505400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16816,
       (string) (len=4) "high": (float64) 16823.23,
@@ -7969,6 +8633,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606507200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17045.9,
       (string) (len=4) "high": (float64) 17069.03,
@@ -7981,6 +8646,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606509000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17078.7,
       (string) (len=4) "high": (float64) 17137.09,
@@ -7993,6 +8659,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606510800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17010.02,
       (string) (len=4) "high": (float64) 17095.29,
@@ -8005,6 +8672,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606512600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17002.85,
       (string) (len=4) "high": (float64) 17031.12,
@@ -8017,6 +8685,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606514400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16971.44,
       (string) (len=4) "high": (float64) 17056.97,
@@ -8029,6 +8698,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606516200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16976.33,
       (string) (len=4) "high": (float64) 17029.7,
@@ -8041,6 +8711,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606518000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17070.82,
       (string) (len=4) "high": (float64) 17088.06,
@@ -8053,6 +8724,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606519800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17153.95,
       (string) (len=4) "high": (float64) 17165.86,
@@ -8065,6 +8737,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606521600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17092.33,
       (string) (len=4) "high": (float64) 17181.91,
@@ -8077,6 +8750,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606523400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17168.77,
       (string) (len=4) "high": (float64) 17176.28,
@@ -8089,6 +8763,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606525200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17175.68,
       (string) (len=4) "high": (float64) 17198,
@@ -8101,6 +8776,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606527000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17149.63,
       (string) (len=4) "high": (float64) 17195.28,
@@ -8113,6 +8789,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606528800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17065.1,
       (string) (len=4) "high": (float64) 17149.97,
@@ -8125,6 +8802,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606530600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17000.71,
       (string) (len=4) "high": (float64) 17090.61,
@@ -8137,6 +8815,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606532400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16956.37,
       (string) (len=4) "high": (float64) 17027.85,
@@ -8149,6 +8828,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606534200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17010.3,
       (string) (len=4) "high": (float64) 17027.97,
@@ -8161,6 +8841,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606536000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16979.99,
       (string) (len=4) "high": (float64) 17045.73,
@@ -8173,6 +8854,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606537800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16973.53,
       (string) (len=4) "high": (float64) 16988.98,
@@ -8185,6 +8867,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606539600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16899.39,
       (string) (len=4) "high": (float64) 16989.03,
@@ -8197,6 +8880,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606541400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16989.03,
       (string) (len=4) "high": (float64) 16989.03,
@@ -8209,6 +8893,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606543200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17008.97,
       (string) (len=4) "high": (float64) 17053.05,
@@ -8221,6 +8906,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606545000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17029.47,
       (string) (len=4) "high": (float64) 17029.47,
@@ -8233,6 +8919,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606546800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17041.53,
       (string) (len=4) "high": (float64) 17075.81,
@@ -8245,6 +8932,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606548600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17025.92,
       (string) (len=4) "high": (float64) 17073.76,
@@ -8257,6 +8945,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606550400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16911.12,
       (string) (len=4) "high": (float64) 17057.9,
@@ -8269,6 +8958,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606552200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16889.6,
       (string) (len=4) "high": (float64) 16938.5,
@@ -8281,6 +8971,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606554000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16956.92,
       (string) (len=4) "high": (float64) 16967.97,
@@ -8293,6 +8984,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606555800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16927.18,
       (string) (len=4) "high": (float64) 16974.37,
@@ -8305,6 +8997,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606557600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17132.51,
       (string) (len=4) "high": (float64) 17135.95,
@@ -8317,6 +9010,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606559400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17199.77,
       (string) (len=4) "high": (float64) 17252.96,
@@ -8329,6 +9023,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606561200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17120.03,
       (string) (len=4) "high": (float64) 17200,
@@ -8341,6 +9036,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606563000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17164.46,
       (string) (len=4) "high": (float64) 17198.1,
@@ -8353,6 +9049,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606564800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17162.16,
       (string) (len=4) "high": (float64) 17231.75,
@@ -8365,6 +9062,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606566600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17143.02,
       (string) (len=4) "high": (float64) 17172.7,
@@ -8377,6 +9075,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606568400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17219.34,
       (string) (len=4) "high": (float64) 17221.13,
@@ -8389,6 +9088,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606570200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17370.99,
       (string) (len=4) "high": (float64) 17374.21,
@@ -8401,6 +9101,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606572000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17343.13,
       (string) (len=4) "high": (float64) 17411.26,
@@ -8413,6 +9114,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606573800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17351.51,
       (string) (len=4) "high": (float64) 17373.56,
@@ -8425,6 +9127,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606575600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17383.91,
       (string) (len=4) "high": (float64) 17444.88,
@@ -8437,6 +9140,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606577400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17533.05,
       (string) (len=4) "high": (float64) 17534.03,
@@ -8449,6 +9153,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606579200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17666.57,
       (string) (len=4) "high": (float64) 17749.49,
@@ -8461,6 +9166,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606581000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17731.58,
       (string) (len=4) "high": (float64) 17789,
@@ -8473,6 +9179,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606582800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17707.56,
       (string) (len=4) "high": (float64) 17768.74,
@@ -8485,6 +9192,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606584600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17768.94,
       (string) (len=4) "high": (float64) 17771.11,
@@ -8497,6 +9205,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606586400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17701.58,
       (string) (len=4) "high": (float64) 17787.54,
@@ -8509,6 +9218,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606588200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17742.11,
       (string) (len=4) "high": (float64) 17762.19,
@@ -8521,6 +9231,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606590000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17719.34,
       (string) (len=4) "high": (float64) 17758.64,
@@ -8533,6 +9244,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606591800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17843.78,
       (string) (len=4) "high": (float64) 17933.25,
@@ -8545,6 +9257,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606593600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17807.74,
       (string) (len=4) "high": (float64) 17902.88,
@@ -8557,6 +9270,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606595400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17692.45,
       (string) (len=4) "high": (float64) 17847.31,
@@ -8569,6 +9283,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606597200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17724.62,
       (string) (len=4) "high": (float64) 17772.06,
@@ -8581,6 +9296,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606599000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17762.22,
       (string) (len=4) "high": (float64) 17770,
@@ -8593,6 +9309,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606600800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17685.01,
       (string) (len=4) "high": (float64) 17774.5,
@@ -8605,6 +9322,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606602600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17777.36,
       (string) (len=4) "high": (float64) 17849.99,
@@ -8617,6 +9335,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606604400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17796.6,
       (string) (len=4) "high": (float64) 17821.47,
@@ -8629,6 +9348,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606606200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17739.85,
       (string) (len=4) "high": (float64) 17796.89,
@@ -8641,6 +9361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606608000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17564.83,
       (string) (len=4) "high": (float64) 17781.46,
@@ -8653,6 +9374,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606609800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17668.84,
       (string) (len=4) "high": (float64) 17669.02,
@@ -8665,6 +9387,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606611600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17581.3,
       (string) (len=4) "high": (float64) 17680.69,
@@ -8677,6 +9400,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606613400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17599,
       (string) (len=4) "high": (float64) 17646.99,
@@ -8689,6 +9413,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606615200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17647.84,
       (string) (len=4) "high": (float64) 17684.1,
@@ -8701,6 +9426,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606617000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17758.89,
       (string) (len=4) "high": (float64) 17765.76,
@@ -8713,6 +9439,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606618800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17780.01,
       (string) (len=4) "high": (float64) 17816.99,
@@ -8725,6 +9452,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606620600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17887.22,
       (string) (len=4) "high": (float64) 17900,
@@ -8737,6 +9465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606622400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17808.78,
       (string) (len=4) "high": (float64) 17884.61,
@@ -8749,6 +9478,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606624200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17778.49,
       (string) (len=4) "high": (float64) 17828.61,
@@ -8761,6 +9491,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606626000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17823.56,
       (string) (len=4) "high": (float64) 17847.48,
@@ -8773,6 +9504,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606627800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17807.76,
       (string) (len=4) "high": (float64) 17848.38,
@@ -8785,6 +9517,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606629600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17740.55,
       (string) (len=4) "high": (float64) 17809.34,
@@ -8797,6 +9530,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606631400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17743.85,
       (string) (len=4) "high": (float64) 17795.88,
@@ -8809,6 +9543,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606633200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17822,
       (string) (len=4) "high": (float64) 17822,
@@ -8821,6 +9556,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606635000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17829.18,
       (string) (len=4) "high": (float64) 17857.78,
@@ -8833,6 +9569,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606636800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18108.92,
       (string) (len=4) "high": (float64) 18132.27,
@@ -8845,6 +9582,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606638600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18157.54,
       (string) (len=4) "high": (float64) 18165.05,
@@ -8857,6 +9595,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606640400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18176.63,
       (string) (len=4) "high": (float64) 18199,
@@ -8869,6 +9608,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606642200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18113,
       (string) (len=4) "high": (float64) 18230,
@@ -8881,6 +9621,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606644000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18147.91,
       (string) (len=4) "high": (float64) 18154.39,
@@ -8893,6 +9634,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606645800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18198.66,
       (string) (len=4) "high": (float64) 18230.33,
@@ -8905,6 +9647,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606647600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18086.48,
       (string) (len=4) "high": (float64) 18248.21,
@@ -8917,6 +9660,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606649400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18098.98,
       (string) (len=4) "high": (float64) 18121.1,
@@ -8929,6 +9673,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606651200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18036.71,
       (string) (len=4) "high": (float64) 18145.25,
@@ -8941,6 +9686,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606653000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18038.78,
       (string) (len=4) "high": (float64) 18090,
@@ -8953,6 +9699,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606654800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18097.56,
       (string) (len=4) "high": (float64) 18139.87,
@@ -8965,6 +9712,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606656600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18112.58,
       (string) (len=4) "high": (float64) 18112.58,
@@ -8977,6 +9725,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606658400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18129.32,
       (string) (len=4) "high": (float64) 18208.87,
@@ -8989,6 +9738,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606660200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18055.21,
       (string) (len=4) "high": (float64) 18131.5,
@@ -9001,6 +9751,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606662000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18122.94,
       (string) (len=4) "high": (float64) 18149.1,
@@ -9013,6 +9764,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606663800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18130.35,
       (string) (len=4) "high": (float64) 18165.27,
@@ -9025,6 +9777,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606665600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18005.9,
       (string) (len=4) "high": (float64) 18165,
@@ -9037,6 +9790,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606667400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18112.12,
       (string) (len=4) "high": (float64) 18115.72,
@@ -9049,6 +9803,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606669200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18117.92,
       (string) (len=4) "high": (float64) 18140.01,
@@ -9061,6 +9816,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606671000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18114.9,
       (string) (len=4) "high": (float64) 18160,
@@ -9073,6 +9829,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606672800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18071.22,
       (string) (len=4) "high": (float64) 18117.03,
@@ -9085,6 +9842,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606674600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18136.22,
       (string) (len=4) "high": (float64) 18145,
@@ -9097,6 +9855,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606676400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18068.82,
       (string) (len=4) "high": (float64) 18145,
@@ -9109,6 +9868,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606678200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18066.69,
       (string) (len=4) "high": (float64) 18110.27,
@@ -9121,6 +9881,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606680000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18180.01,
       (string) (len=4) "high": (float64) 18194.99,
@@ -9133,6 +9894,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606681800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18228.37,
       (string) (len=4) "high": (float64) 18242.54,
@@ -9145,6 +9907,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606683600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18300.06,
       (string) (len=4) "high": (float64) 18359,
@@ -9157,6 +9920,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606685400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18274.99,
       (string) (len=4) "high": (float64) 18337.26,
@@ -9169,6 +9933,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606687200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18130.01,
       (string) (len=4) "high": (float64) 18289.31,
@@ -9181,6 +9946,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606689000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18158.13,
       (string) (len=4) "high": (float64) 18220.46,
@@ -9193,6 +9959,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606690800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18224.54,
       (string) (len=4) "high": (float64) 18258.22,
@@ -9205,6 +9972,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606692600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18202.04,
       (string) (len=4) "high": (float64) 18223.13,
@@ -9217,6 +9985,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606694400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18399.99,
       (string) (len=4) "high": (float64) 18400,
@@ -9229,6 +9998,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606696200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18454.01,
       (string) (len=4) "high": (float64) 18490,
@@ -9241,6 +10011,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606698000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18405.87,
       (string) (len=4) "high": (float64) 18516.36,
@@ -9253,6 +10024,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606699800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18501.08,
       (string) (len=4) "high": (float64) 18564.31,
@@ -9265,6 +10037,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606701600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18514.77,
       (string) (len=4) "high": (float64) 18545.37,
@@ -9277,6 +10050,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606703400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18528.36,
       (string) (len=4) "high": (float64) 18574.46,
@@ -9289,6 +10063,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606705200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18591.03,
       (string) (len=4) "high": (float64) 18597.79,
@@ -9301,6 +10076,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606707000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18606.02,
       (string) (len=4) "high": (float64) 18612.87,
@@ -9313,6 +10089,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606708800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18491.51,
       (string) (len=4) "high": (float64) 18636.77,
@@ -9325,6 +10102,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606710600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18542.16,
       (string) (len=4) "high": (float64) 18562.11,
@@ -9337,6 +10115,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606712400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18625,
       (string) (len=4) "high": (float64) 18625,
@@ -9349,6 +10128,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606714200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18539.96,
       (string) (len=4) "high": (float64) 18640,
@@ -9361,6 +10141,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606716000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18506.47,
       (string) (len=4) "high": (float64) 18578.79,
@@ -9373,6 +10154,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606717800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18549.66,
       (string) (len=4) "high": (float64) 18566.66,
@@ -9385,6 +10167,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606719600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18684.85,
       (string) (len=4) "high": (float64) 18693.43,
@@ -9397,6 +10180,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606721400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18634.68,
       (string) (len=4) "high": (float64) 18694.96,
@@ -9409,6 +10193,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606723200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18442.55,
       (string) (len=4) "high": (float64) 18634.73,
@@ -9421,6 +10206,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606725000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18477.05,
       (string) (len=4) "high": (float64) 18536.99,
@@ -9433,6 +10219,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606726800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18417.55,
       (string) (len=4) "high": (float64) 18523.63,
@@ -9445,6 +10232,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606728600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18493.43,
       (string) (len=4) "high": (float64) 18500.26,
@@ -9457,6 +10245,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606730400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18556.87,
       (string) (len=4) "high": (float64) 18569.15,
@@ -9469,6 +10258,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606732200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18512.3,
       (string) (len=4) "high": (float64) 18591.21,
@@ -9481,6 +10271,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606734000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18640.94,
       (string) (len=4) "high": (float64) 18664.56,
@@ -9493,6 +10284,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606735800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18611.27,
       (string) (len=4) "high": (float64) 18675,
@@ -9505,6 +10297,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606737600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18782.07,
       (string) (len=4) "high": (float64) 18819.34,
@@ -9517,6 +10310,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606739400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18860.9,
       (string) (len=4) "high": (float64) 18861.11,
@@ -9529,6 +10323,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606741200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18949.99,
       (string) (len=4) "high": (float64) 18950,
@@ -9541,6 +10336,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606743000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19175.71,
       (string) (len=4) "high": (float64) 19239.33,
@@ -9553,6 +10349,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606744800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19290,
       (string) (len=4) "high": (float64) 19350.01,
@@ -9565,6 +10362,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606746600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19500,
       (string) (len=4) "high": (float64) 19829.47,
@@ -9577,6 +10375,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606748400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19677.96,
       (string) (len=4) "high": (float64) 19873.23,
@@ -9589,6 +10388,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606750200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19281.35,
       (string) (len=4) "high": (float64) 19699.95,
@@ -9601,6 +10401,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606752000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19513.62,
       (string) (len=4) "high": (float64) 19588.53,
@@ -9613,6 +10414,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606753800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19185.35,
       (string) (len=4) "high": (float64) 19525.87,
@@ -9625,6 +10427,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606755600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19282.49,
       (string) (len=4) "high": (float64) 19325.77,
@@ -9637,6 +10440,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606757400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19392.04,
       (string) (len=4) "high": (float64) 19467.48,
@@ -9649,6 +10453,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606759200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19242.23,
       (string) (len=4) "high": (float64) 19474.69,
@@ -9661,6 +10466,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606761000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19186.78,
       (string) (len=4) "high": (float64) 19348.39,
@@ -9673,6 +10479,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606762800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19300.72,
       (string) (len=4) "high": (float64) 19310,
@@ -9685,6 +10492,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606764600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19262.72,
       (string) (len=4) "high": (float64) 19314.32,
@@ -9697,6 +10505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606766400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19422.57,
       (string) (len=4) "high": (float64) 19435.83,
@@ -9709,6 +10518,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606768200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19439.79,
       (string) (len=4) "high": (float64) 19490.04,
@@ -9721,6 +10531,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606770000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19450.86,
       (string) (len=4) "high": (float64) 19519.74,
@@ -9733,6 +10544,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606771800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19382,
       (string) (len=4) "high": (float64) 19471.69,
@@ -9745,6 +10557,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606773600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19386.39,
       (string) (len=4) "high": (float64) 19388.61,
@@ -9757,6 +10570,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606775400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19500,
       (string) (len=4) "high": (float64) 19500,
@@ -9769,6 +10583,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606777200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19624.75,
       (string) (len=4) "high": (float64) 19624.75,
@@ -9781,6 +10596,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606779000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19713.94,
       (string) (len=4) "high": (float64) 19775,
@@ -9793,6 +10609,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606780800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19683.3,
       (string) (len=4) "high": (float64) 19730,
@@ -9805,6 +10622,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606782600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19573.18,
       (string) (len=4) "high": (float64) 19692.63,
@@ -9817,6 +10635,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606784400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19502.48,
       (string) (len=4) "high": (float64) 19649,
@@ -9829,6 +10648,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606786200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19603.97,
       (string) (len=4) "high": (float64) 19642.69,
@@ -9841,6 +10661,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606788000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19640.81,
       (string) (len=4) "high": (float64) 19680,
@@ -9853,6 +10674,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606789800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19691.22,
       (string) (len=4) "high": (float64) 19718.4,
@@ -9865,6 +10687,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606791600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19574.73,
       (string) (len=4) "high": (float64) 19693.21,
@@ -9877,6 +10700,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606793400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19440.51,
       (string) (len=4) "high": (float64) 19599.71,
@@ -9889,6 +10713,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606795200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19445.76,
       (string) (len=4) "high": (float64) 19532.58,
@@ -9901,6 +10726,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606797000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19366.73,
       (string) (len=4) "high": (float64) 19491.91,
@@ -9913,6 +10739,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606798800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19440.86,
       (string) (len=4) "high": (float64) 19440.92,
@@ -9925,6 +10752,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606800600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19490.88,
       (string) (len=4) "high": (float64) 19509.11,
@@ -9937,6 +10765,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606802400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19475.01,
       (string) (len=4) "high": (float64) 19524.01,
@@ -9949,6 +10778,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606804200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19347.27,
       (string) (len=4) "high": (float64) 19475.01,
@@ -9961,6 +10791,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606806000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19456.96,
       (string) (len=4) "high": (float64) 19504.94,
@@ -9973,6 +10804,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606807800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19524.69,
       (string) (len=4) "high": (float64) 19556.44,
@@ -9985,6 +10817,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606809600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19534.36,
       (string) (len=4) "high": (float64) 19568.91,
@@ -9997,6 +10830,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606811400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19479.29,
       (string) (len=4) "high": (float64) 19577.47,
@@ -10009,6 +10843,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606813200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19462.24,
       (string) (len=4) "high": (float64) 19560.02,
@@ -10021,6 +10856,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606815000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19579.37,
       (string) (len=4) "high": (float64) 19583.01,
@@ -10033,6 +10869,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606816800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19771.91,
       (string) (len=4) "high": (float64) 19785,
@@ -10045,6 +10882,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606818600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19757.83,
       (string) (len=4) "high": (float64) 19824,
@@ -10057,6 +10895,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606820400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19354.91,
       (string) (len=4) "high": (float64) 19915.14,
@@ -10069,6 +10908,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606822200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19450.84,
       (string) (len=4) "high": (float64) 19592.08,
@@ -10081,6 +10921,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606824000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18734.19,
       (string) (len=4) "high": (float64) 19489.18,
@@ -10093,6 +10934,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606825800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18577.6,
       (string) (len=4) "high": (float64) 18998.99,
@@ -10105,6 +10947,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606827600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18751.3,
       (string) (len=4) "high": (float64) 18784.99,
@@ -10117,6 +10960,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606829400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18788.75,
       (string) (len=4) "high": (float64) 18875.65,
@@ -10129,6 +10973,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606831200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18866.6,
       (string) (len=4) "high": (float64) 18974.77,
@@ -10141,6 +10986,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606833000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19308.99,
       (string) (len=4) "high": (float64) 19386.73,
@@ -10153,6 +10999,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606834800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19436.72,
       (string) (len=4) "high": (float64) 19500,
@@ -10165,6 +11012,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606836600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19281.99,
       (string) (len=4) "high": (float64) 19442.84,
@@ -10177,6 +11025,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606838400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18998.02,
       (string) (len=4) "high": (float64) 19346.31,
@@ -10189,6 +11038,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606840200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19058.17,
       (string) (len=4) "high": (float64) 19181.83,
@@ -10201,6 +11051,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606842000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18945.8,
       (string) (len=4) "high": (float64) 19091.93,
@@ -10213,6 +11064,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606843800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19057.88,
       (string) (len=4) "high": (float64) 19091.93,
@@ -10225,6 +11077,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606845600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18879.32,
       (string) (len=4) "high": (float64) 19063.53,
@@ -10237,6 +11090,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606847400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18746.07,
       (string) (len=4) "high": (float64) 18994.69,
@@ -10249,6 +11103,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606849200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18914.86,
       (string) (len=4) "high": (float64) 18990,
@@ -10261,6 +11116,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606851000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19087.7,
       (string) (len=4) "high": (float64) 19148.97,
@@ -10273,6 +11129,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606852800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18992.01,
       (string) (len=4) "high": (float64) 19153.43,
@@ -10285,6 +11142,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606854600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19041.96,
       (string) (len=4) "high": (float64) 19046.82,
@@ -10297,6 +11155,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606856400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19175,
       (string) (len=4) "high": (float64) 19175,
@@ -10309,6 +11168,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606858200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19057.46,
       (string) (len=4) "high": (float64) 19220,
@@ -10321,6 +11181,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606860000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19092.25,
       (string) (len=4) "high": (float64) 19175.42,
@@ -10333,6 +11194,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606861800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18912.01,
       (string) (len=4) "high": (float64) 19127.57,
@@ -10345,6 +11207,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606863600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18745.64,
       (string) (len=4) "high": (float64) 18958.13,
@@ -10357,6 +11220,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606865400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18782.97,
       (string) (len=4) "high": (float64) 18885.29,
@@ -10369,6 +11233,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606867200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18779.58,
       (string) (len=4) "high": (float64) 18795.05,
@@ -10381,6 +11246,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606869000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18847.92,
       (string) (len=4) "high": (float64) 18890,
@@ -10393,6 +11259,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606870800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18793.82,
       (string) (len=4) "high": (float64) 18842.27,
@@ -10405,6 +11272,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606872600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18866.41,
       (string) (len=4) "high": (float64) 18985.99,
@@ -10417,6 +11285,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606874400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18774.82,
       (string) (len=4) "high": (float64) 18866.97,
@@ -10429,6 +11298,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606876200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18693.14,
       (string) (len=4) "high": (float64) 18799.43,
@@ -10441,6 +11311,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606878000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18586.29,
       (string) (len=4) "high": (float64) 18807.27,
@@ -10453,6 +11324,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606879800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18627.9,
       (string) (len=4) "high": (float64) 18697.86,
@@ -10465,6 +11337,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606881600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18396.28,
       (string) (len=4) "high": (float64) 18712.51,
@@ -10477,6 +11350,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606883400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18566.71,
       (string) (len=4) "high": (float64) 18599.99,
@@ -10489,6 +11363,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606885200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18500,
       (string) (len=4) "high": (float64) 18649,
@@ -10501,6 +11376,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606887000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18666.36,
       (string) (len=4) "high": (float64) 18675.05,
@@ -10513,6 +11389,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606888800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18796.25,
       (string) (len=4) "high": (float64) 18822.15,
@@ -10525,6 +11402,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606890600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18932.64,
       (string) (len=4) "high": (float64) 18946.96,
@@ -10537,6 +11415,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606892400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18867.12,
       (string) (len=4) "high": (float64) 19000,
@@ -10549,6 +11428,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606894200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19130.78,
       (string) (len=4) "high": (float64) 19133.33,
@@ -10561,6 +11441,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606896000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19332.4,
       (string) (len=4) "high": (float64) 19340,
@@ -10573,6 +11454,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606897800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19200,
       (string) (len=4) "high": (float64) 19339.99,
@@ -10585,6 +11467,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606899600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19250.61,
       (string) (len=4) "high": (float64) 19315.21,
@@ -10597,6 +11480,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606901400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19028.71,
       (string) (len=4) "high": (float64) 19255.78,
@@ -10609,6 +11493,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606903200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19106.71,
       (string) (len=4) "high": (float64) 19154.32,
@@ -10621,6 +11506,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606905000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19107.57,
       (string) (len=4) "high": (float64) 19198.66,
@@ -10633,6 +11519,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606906800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19137.32,
       (string) (len=4) "high": (float64) 19191.01,
@@ -10645,6 +11532,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606908600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19130.28,
       (string) (len=4) "high": (float64) 19195,
@@ -10657,6 +11545,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606910400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18955.09,
       (string) (len=4) "high": (float64) 19130.42,
@@ -10669,6 +11558,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606912200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18949.03,
       (string) (len=4) "high": (float64) 18968.22,
@@ -10681,6 +11571,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606914000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19212.11,
       (string) (len=4) "high": (float64) 19248.17,
@@ -10693,6 +11584,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606915800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19122.33,
       (string) (len=4) "high": (float64) 19264.6,
@@ -10705,6 +11597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606917600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18984.94,
       (string) (len=4) "high": (float64) 19172.49,
@@ -10717,6 +11610,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606919400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18914.17,
       (string) (len=4) "high": (float64) 19012.45,
@@ -10729,6 +11623,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606921200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18846.22,
       (string) (len=4) "high": (float64) 19000,
@@ -10741,6 +11636,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606923000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18900.38,
       (string) (len=4) "high": (float64) 18936.1,
@@ -10753,6 +11649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606924800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18986.21,
       (string) (len=4) "high": (float64) 19019.63,
@@ -10765,6 +11662,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606926600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18867.65,
       (string) (len=4) "high": (float64) 18990.53,
@@ -10777,6 +11675,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606928400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18916.69,
       (string) (len=4) "high": (float64) 18963.15,
@@ -10789,6 +11688,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606930200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18991.51,
       (string) (len=4) "high": (float64) 19018.2,
@@ -10801,6 +11701,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606932000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19078.42,
       (string) (len=4) "high": (float64) 19085.28,
@@ -10813,6 +11714,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606933800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19024.39,
       (string) (len=4) "high": (float64) 19080.22,
@@ -10825,6 +11727,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606935600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19019.23,
       (string) (len=4) "high": (float64) 19130.99,
@@ -10837,6 +11740,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606937400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19120.42,
       (string) (len=4) "high": (float64) 19147.73,
@@ -10849,6 +11753,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606939200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.79,
       (string) (len=4) "high": (float64) 19165.94,
@@ -10861,6 +11766,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606941000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.41,
       (string) (len=4) "high": (float64) 19159,
@@ -10873,6 +11779,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606942800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19057.93,
       (string) (len=4) "high": (float64) 19169.99,
@@ -10885,6 +11792,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606944600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19155.01,
       (string) (len=4) "high": (float64) 19160,
@@ -10897,6 +11805,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606946400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19172.35,
       (string) (len=4) "high": (float64) 19240,
@@ -10909,6 +11818,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606948200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19126.69,
       (string) (len=4) "high": (float64) 19207.44,
@@ -10921,6 +11831,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606950000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19206.02,
       (string) (len=4) "high": (float64) 19212.13,
@@ -10933,6 +11844,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606951800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19225.63,
       (string) (len=4) "high": (float64) 19274.3,
@@ -10945,6 +11857,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606953600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19237,
       (string) (len=4) "high": (float64) 19300,
@@ -10957,6 +11870,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606955400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19193.53,
       (string) (len=4) "high": (float64) 19239.03,
@@ -10969,6 +11883,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606957200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.77,
       (string) (len=4) "high": (float64) 19193.55,
@@ -10981,6 +11896,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606959000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19031.03,
       (string) (len=4) "high": (float64) 19100,
@@ -10993,6 +11909,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606960800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19032.88,
       (string) (len=4) "high": (float64) 19097.93,
@@ -11005,6 +11922,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606962600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19058.75,
       (string) (len=4) "high": (float64) 19101.03,
@@ -11017,6 +11935,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606964400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19126.52,
       (string) (len=4) "high": (float64) 19164.77,
@@ -11029,6 +11948,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606966200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19099.19,
       (string) (len=4) "high": (float64) 19190,
@@ -11041,6 +11961,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606968000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19064.28,
       (string) (len=4) "high": (float64) 19127.51,
@@ -11053,6 +11974,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606969800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19049.17,
       (string) (len=4) "high": (float64) 19099.5,
@@ -11065,6 +11987,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606971600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19115.16,
       (string) (len=4) "high": (float64) 19123.41,
@@ -11077,6 +12000,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606973400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18929.44,
       (string) (len=4) "high": (float64) 19116.02,
@@ -11089,6 +12013,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606975200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18998.34,
       (string) (len=4) "high": (float64) 19015.68,
@@ -11101,6 +12026,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606977000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18974.45,
       (string) (len=4) "high": (float64) 19012.14,
@@ -11113,6 +12039,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606978800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19082.94,
       (string) (len=4) "high": (float64) 19089.19,
@@ -11125,6 +12052,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606980600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19208.47,
       (string) (len=4) "high": (float64) 19255.41,
@@ -11137,6 +12065,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606982400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19434.3,
       (string) (len=4) "high": (float64) 19466.58,
@@ -11149,6 +12078,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606984200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19390.91,
       (string) (len=4) "high": (float64) 19466.19,
@@ -11161,6 +12091,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606986000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19197.43,
       (string) (len=4) "high": (float64) 19434.96,
@@ -11173,6 +12104,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606987800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19375,
       (string) (len=4) "high": (float64) 19375,
@@ -11185,6 +12117,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606989600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19405.42,
       (string) (len=4) "high": (float64) 19412.93,
@@ -11197,6 +12130,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606991400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19364.44,
       (string) (len=4) "high": (float64) 19435.49,
@@ -11209,6 +12143,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606993200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19433.87,
       (string) (len=4) "high": (float64) 19460,
@@ -11221,6 +12156,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606995000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19411.84,
       (string) (len=4) "high": (float64) 19444.77,
@@ -11233,6 +12169,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606996800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19320.16,
       (string) (len=4) "high": (float64) 19440.09,
@@ -11245,6 +12182,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606998600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19350.11,
       (string) (len=4) "high": (float64) 19359.47,
@@ -11257,6 +12195,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607000400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19360.91,
       (string) (len=4) "high": (float64) 19398.19,
@@ -11269,6 +12208,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607002200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19302.3,
       (string) (len=4) "high": (float64) 19387.86,
@@ -11281,6 +12221,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607004000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19392.25,
       (string) (len=4) "high": (float64) 19429.34,
@@ -11293,6 +12234,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607005800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19370.06,
       (string) (len=4) "high": (float64) 19392.78,
@@ -11305,6 +12247,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607007600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19410.89,
       (string) (len=4) "high": (float64) 19419.49,
@@ -11317,6 +12260,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607009400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19556.13,
       (string) (len=4) "high": (float64) 19558.78,
@@ -11329,6 +12273,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607011200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19393.76,
       (string) (len=4) "high": (float64) 19625.64,
@@ -11341,6 +12286,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607013000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19380.28,
       (string) (len=4) "high": (float64) 19456.71,
@@ -11353,6 +12299,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607014800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19297.62,
       (string) (len=4) "high": (float64) 19403.32,
@@ -11365,6 +12312,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607016600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19317.03,
       (string) (len=4) "high": (float64) 19332.12,
@@ -11377,6 +12325,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607018400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19389.07,
       (string) (len=4) "high": (float64) 19398.73,
@@ -11389,6 +12338,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607020200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19400.25,
       (string) (len=4) "high": (float64) 19418.63,
@@ -11401,6 +12351,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607022000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19365.28,
       (string) (len=4) "high": (float64) 19406.31,
@@ -11413,6 +12364,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607023800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19442.2,
       (string) (len=4) "high": (float64) 19450,
@@ -11425,6 +12377,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607025600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19411.46,
       (string) (len=4) "high": (float64) 19465,
@@ -11437,6 +12390,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607027400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19387.59,
       (string) (len=4) "high": (float64) 19424.49,
@@ -11449,6 +12403,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607029200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19401.26,
       (string) (len=4) "high": (float64) 19417.4,
@@ -11461,6 +12416,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607031000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19463.29,
       (string) (len=4) "high": (float64) 19475,
@@ -11473,6 +12429,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607032800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19497.05,
       (string) (len=4) "high": (float64) 19497.35,
@@ -11485,6 +12442,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607034600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19489.22,
       (string) (len=4) "high": (float64) 19497.35,
@@ -11497,6 +12455,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607036400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19466.29,
       (string) (len=4) "high": (float64) 19556.3,
@@ -11509,6 +12468,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607038200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19448.64,
       (string) (len=4) "high": (float64) 19479.27,
@@ -11521,6 +12481,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607040000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19484.61,
       (string) (len=4) "high": (float64) 19493,
@@ -11533,6 +12494,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607041800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19491.95,
       (string) (len=4) "high": (float64) 19546.46,
@@ -11545,6 +12507,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607043600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19398.99,
       (string) (len=4) "high": (float64) 19512.13,
@@ -11557,6 +12520,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607045400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19347,
       (string) (len=4) "high": (float64) 19412.16,
@@ -11569,6 +12533,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607047200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19374.84,
       (string) (len=4) "high": (float64) 19395.49,
@@ -11581,6 +12546,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607049000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19273.01,
       (string) (len=4) "high": (float64) 19375.63,
@@ -11593,6 +12559,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607050800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19245.05,
       (string) (len=4) "high": (float64) 19340.99,
@@ -11605,6 +12572,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607052600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19183.49,
       (string) (len=4) "high": (float64) 19294.64,
@@ -11617,6 +12585,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607054400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19287.93,
       (string) (len=4) "high": (float64) 19289.92,
@@ -11629,6 +12598,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607056200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19311.53,
       (string) (len=4) "high": (float64) 19350,
@@ -11641,6 +12611,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607058000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19316.76,
       (string) (len=4) "high": (float64) 19332.04,
@@ -11653,6 +12624,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607059800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19214.37,
       (string) (len=4) "high": (float64) 19316.86,
@@ -11665,6 +12637,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607061600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19375,
       (string) (len=4) "high": (float64) 19375,
@@ -11677,6 +12650,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607063400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19330.62,
       (string) (len=4) "high": (float64) 19375,
@@ -11689,6 +12663,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607065200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19294.58,
       (string) (len=4) "high": (float64) 19330.62,
@@ -11701,6 +12676,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607067000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19309.62,
       (string) (len=4) "high": (float64) 19348.25,
@@ -11713,6 +12689,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607068800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19442.78,
       (string) (len=4) "high": (float64) 19442.78,
@@ -11725,6 +12702,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607070600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19405.42,
       (string) (len=4) "high": (float64) 19464.06,
@@ -11737,6 +12715,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607072400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19351.74,
       (string) (len=4) "high": (float64) 19422.54,
@@ -11749,6 +12728,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607074200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19378.88,
       (string) (len=4) "high": (float64) 19397.23,
@@ -11761,6 +12741,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607076000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18972.14,
       (string) (len=4) "high": (float64) 19378.88,
@@ -11773,6 +12754,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607077800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19003.15,
       (string) (len=4) "high": (float64) 19078.96,
@@ -11785,6 +12767,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607079600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19003.22,
       (string) (len=4) "high": (float64) 19130.91,
@@ -11797,6 +12780,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607081400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18837.41,
       (string) (len=4) "high": (float64) 19079.89,
@@ -11809,6 +12793,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607083200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18877.25,
       (string) (len=4) "high": (float64) 18902.15,
@@ -11821,6 +12806,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607085000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19038.91,
       (string) (len=4) "high": (float64) 19055.69,
@@ -11833,6 +12819,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607086800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18991.01,
       (string) (len=4) "high": (float64) 19046.62,
@@ -11845,6 +12832,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607088600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19023.89,
       (string) (len=4) "high": (float64) 19045.34,
@@ -11857,6 +12845,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607090400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19150,
       (string) (len=4) "high": (float64) 19161.63,
@@ -11869,6 +12858,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607092200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19065.67,
       (string) (len=4) "high": (float64) 19157.87,
@@ -11881,6 +12871,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607094000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18985.8,
       (string) (len=4) "high": (float64) 19092.89,
@@ -11893,6 +12884,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607095800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18966.96,
       (string) (len=4) "high": (float64) 19026.79,
@@ -11905,6 +12897,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607097600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18924.7,
       (string) (len=4) "high": (float64) 18997.74,
@@ -11917,6 +12910,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607099400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18995.39,
       (string) (len=4) "high": (float64) 18998,
@@ -11929,6 +12923,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607101200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18996.07,
       (string) (len=4) "high": (float64) 19037.24,
@@ -11941,6 +12936,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607103000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18977.07,
       (string) (len=4) "high": (float64) 19032.16,
@@ -11953,6 +12949,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607104800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18997.14,
       (string) (len=4) "high": (float64) 19004.74,
@@ -11965,6 +12962,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607106600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19069.75,
       (string) (len=4) "high": (float64) 19084.76,
@@ -11977,6 +12975,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607108400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19024.01,
       (string) (len=4) "high": (float64) 19078.67,
@@ -11989,6 +12988,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607110200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19056.01,
       (string) (len=4) "high": (float64) 19075.29,
@@ -12001,6 +13001,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607112000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19010.45,
       (string) (len=4) "high": (float64) 19059.44,
@@ -12013,6 +13014,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607113800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18978.53,
       (string) (len=4) "high": (float64) 19013.72,
@@ -12025,6 +13027,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607115600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18839.98,
       (string) (len=4) "high": (float64) 19005.96,
@@ -12037,6 +13040,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607117400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18821.5,
       (string) (len=4) "high": (float64) 18907.61,
@@ -12049,6 +13053,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607119200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18790.32,
       (string) (len=4) "high": (float64) 18886.1,
@@ -12061,6 +13066,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607121000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18673.76,
       (string) (len=4) "high": (float64) 18845,
@@ -12073,6 +13079,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607122800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18834.95,
       (string) (len=4) "high": (float64) 18852.43,
@@ -12085,6 +13092,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607124600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18658.1,
       (string) (len=4) "high": (float64) 18840.52,
@@ -12097,6 +13105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607126400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18624.04,
       (string) (len=4) "high": (float64) 18696.94,
@@ -12109,6 +13118,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607128200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18785.37,
       (string) (len=4) "high": (float64) 18811.28,
@@ -12121,6 +13131,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607130000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18746.73,
       (string) (len=4) "high": (float64) 18832.26,
@@ -12133,6 +13144,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607131800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18665.38,
       (string) (len=4) "high": (float64) 18797,
@@ -12145,6 +13157,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607133600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18773.41,
       (string) (len=4) "high": (float64) 18778.94,
@@ -12157,6 +13170,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607135400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18815.43,
       (string) (len=4) "high": (float64) 18864.95,
@@ -12169,6 +13183,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607137200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18868.89,
       (string) (len=4) "high": (float64) 18888.88,
@@ -12181,6 +13196,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607139000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18831.82,
       (string) (len=4) "high": (float64) 18900,
@@ -12193,6 +13209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607140800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18924.79,
       (string) (len=4) "high": (float64) 18924.79,
@@ -12205,6 +13222,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607142600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18884.92,
       (string) (len=4) "high": (float64) 18951.99,
@@ -12217,6 +13235,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607144400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18881.14,
       (string) (len=4) "high": (float64) 18904.36,
@@ -12229,6 +13248,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607146200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18973.07,
       (string) (len=4) "high": (float64) 18985.97,
@@ -12241,6 +13261,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607148000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18940.11,
       (string) (len=4) "high": (float64) 18984.28,
@@ -12253,6 +13274,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607149800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18983.07,
       (string) (len=4) "high": (float64) 18999,
@@ -12265,6 +13287,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607151600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18958.69,
       (string) (len=4) "high": (float64) 18999,
@@ -12277,6 +13300,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607153400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18931.01,
       (string) (len=4) "high": (float64) 18998.95,
@@ -12289,6 +13313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607155200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19099.99,
       (string) (len=4) "high": (float64) 19100,
@@ -12301,6 +13326,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607157000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19168.21,
       (string) (len=4) "high": (float64) 19189.98,
@@ -12313,6 +13339,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607158800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19115,
       (string) (len=4) "high": (float64) 19175,
@@ -12325,6 +13352,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607160600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19128.09,
       (string) (len=4) "high": (float64) 19131.63,
@@ -12337,6 +13365,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607162400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19085.45,
       (string) (len=4) "high": (float64) 19149,
@@ -12349,6 +13378,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607164200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19131.64,
       (string) (len=4) "high": (float64) 19140,
@@ -12361,6 +13391,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607166000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18992.51,
       (string) (len=4) "high": (float64) 19143.1,
@@ -12373,6 +13404,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607167800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19032.92,
       (string) (len=4) "high": (float64) 19060.92,
@@ -12385,6 +13417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607169600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19036.11,
       (string) (len=4) "high": (float64) 19092.08,
@@ -12397,6 +13430,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607171400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19083.32,
       (string) (len=4) "high": (float64) 19091.58,
@@ -12409,6 +13443,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607173200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19010.71,
       (string) (len=4) "high": (float64) 19087.59,
@@ -12421,6 +13456,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607175000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18995.45,
       (string) (len=4) "high": (float64) 19023.11,
@@ -12433,6 +13469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607176800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19015,
       (string) (len=4) "high": (float64) 19059.07,
@@ -12445,6 +13482,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607178600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.17,
       (string) (len=4) "high": (float64) 19099.72,
@@ -12457,6 +13495,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607180400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19091,
       (string) (len=4) "high": (float64) 19163.45,
@@ -12469,6 +13508,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607182200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19126.14,
       (string) (len=4) "high": (float64) 19129,
@@ -12481,6 +13521,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607184000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19079.12,
       (string) (len=4) "high": (float64) 19157.93,
@@ -12493,6 +13534,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607185800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19111.17,
       (string) (len=4) "high": (float64) 19127.25,
@@ -12505,6 +13547,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607187600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19080.56,
       (string) (len=4) "high": (float64) 19118,
@@ -12517,6 +13560,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607189400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19139.41,
       (string) (len=4) "high": (float64) 19139.69,
@@ -12529,6 +13573,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607191200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19137.13,
       (string) (len=4) "high": (float64) 19150,
@@ -12541,6 +13586,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607193000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19130.9,
       (string) (len=4) "high": (float64) 19158,
@@ -12553,6 +13599,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607194800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19106.41,
       (string) (len=4) "high": (float64) 19185.83,
@@ -12565,6 +13612,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607196600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19137,
       (string) (len=4) "high": (float64) 19137.03,
@@ -12577,6 +13625,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607198400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19104.94,
       (string) (len=4) "high": (float64) 19155.61,
@@ -12589,6 +13638,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607200200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19066.66,
       (string) (len=4) "high": (float64) 19136.6,
@@ -12601,6 +13651,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607202000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19072.85,
       (string) (len=4) "high": (float64) 19127.04,
@@ -12613,6 +13664,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607203800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19018.74,
       (string) (len=4) "high": (float64) 19075,
@@ -12625,6 +13677,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607205600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19045.53,
       (string) (len=4) "high": (float64) 19060.92,
@@ -12637,6 +13690,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607207400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19028.68,
       (string) (len=4) "high": (float64) 19067.22,
@@ -12649,6 +13703,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607209200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19085.68,
       (string) (len=4) "high": (float64) 19089.34,
@@ -12661,6 +13716,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607211000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19158.96,
       (string) (len=4) "high": (float64) 19168.52,
@@ -12673,6 +13729,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607212800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19188.44,
       (string) (len=4) "high": (float64) 19275,
@@ -12685,6 +13742,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607214600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19282.34,
       (string) (len=4) "high": (float64) 19297.02,
@@ -12697,6 +13755,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607216400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19309.56,
       (string) (len=4) "high": (float64) 19349,
@@ -12709,6 +13768,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607218200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19267.99,
       (string) (len=4) "high": (float64) 19339.38,
@@ -12721,6 +13781,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607220000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19279.01,
       (string) (len=4) "high": (float64) 19293.02,
@@ -12733,6 +13794,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607221800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19239.61,
       (string) (len=4) "high": (float64) 19287.93,
@@ -12745,6 +13807,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607223600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19200,
       (string) (len=4) "high": (float64) 19255.79,
@@ -12757,6 +13820,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607225400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19199.16,
       (string) (len=4) "high": (float64) 19207.1,
@@ -12769,6 +13833,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607227200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19208.3,
       (string) (len=4) "high": (float64) 19241.93,
@@ -12781,6 +13846,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607229000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19198.43,
       (string) (len=4) "high": (float64) 19238.73,
@@ -12793,6 +13859,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607230800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19134.83,
       (string) (len=4) "high": (float64) 19229.51,
@@ -12805,6 +13872,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607232600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19164.97,
       (string) (len=4) "high": (float64) 19192.75,
@@ -12817,6 +13885,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607234400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19206.98,
       (string) (len=4) "high": (float64) 19220,
@@ -12829,6 +13898,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607236200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19196.66,
       (string) (len=4) "high": (float64) 19237.69,
@@ -12841,6 +13911,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607238000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19252.16,
       (string) (len=4) "high": (float64) 19262.06,
@@ -12853,6 +13924,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607239800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19243.42,
       (string) (len=4) "high": (float64) 19271.99,
@@ -12865,6 +13937,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607241600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19165.65,
       (string) (len=4) "high": (float64) 19264.53,
@@ -12877,6 +13950,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607243400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19033.57,
       (string) (len=4) "high": (float64) 19162.22,
@@ -12889,6 +13963,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607245200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19064.41,
       (string) (len=4) "high": (float64) 19094.86,
@@ -12901,6 +13976,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607247000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19058.34,
       (string) (len=4) "high": (float64) 19094.37,
@@ -12913,6 +13989,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607248800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19035.91,
       (string) (len=4) "high": (float64) 19074.43,
@@ -12925,6 +14002,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607250600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19053.87,
       (string) (len=4) "high": (float64) 19070.12,
@@ -12937,6 +14015,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607252400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18984.49,
       (string) (len=4) "high": (float64) 19061.85,
@@ -12949,6 +14028,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607254200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19100,
       (string) (len=4) "high": (float64) 19108.2,
@@ -12961,6 +14041,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607256000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19073.49,
       (string) (len=4) "high": (float64) 19099.99,
@@ -12973,6 +14054,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607257800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18993.79,
       (string) (len=4) "high": (float64) 19073.52,
@@ -12985,6 +14067,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607259600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19030.98,
       (string) (len=4) "high": (float64) 19031.88,
@@ -12997,6 +14080,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607261400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18968.6,
       (string) (len=4) "high": (float64) 19036.61,
@@ -13009,6 +14093,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607263200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.01,
       (string) (len=4) "high": (float64) 19111.87,
@@ -13021,6 +14106,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607265000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19132.08,
       (string) (len=4) "high": (float64) 19148.48,
@@ -13033,6 +14119,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607266800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19139.31,
       (string) (len=4) "high": (float64) 19172.97,
@@ -13045,6 +14132,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607268600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19145.45,
       (string) (len=4) "high": (float64) 19150.86,
@@ -13057,6 +14145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607270400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19063.25,
       (string) (len=4) "high": (float64) 19219.99,
@@ -13069,6 +14158,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607272200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19122.25,
       (string) (len=4) "high": (float64) 19128.29,
@@ -13081,6 +14171,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607274000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19169.78,
       (string) (len=4) "high": (float64) 19194.9,
@@ -13093,6 +14184,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607275800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19145.83,
       (string) (len=4) "high": (float64) 19179.05,
@@ -13105,6 +14197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607277600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19126.48,
       (string) (len=4) "high": (float64) 19180,
@@ -13117,6 +14210,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607279400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19116.65,
       (string) (len=4) "high": (float64) 19147.55,
@@ -13129,6 +14223,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607281200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.82,
       (string) (len=4) "high": (float64) 19168.02,
@@ -13141,6 +14236,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607283000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19148.17,
       (string) (len=4) "high": (float64) 19156.6,
@@ -13153,6 +14249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607284800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19157.57,
       (string) (len=4) "high": (float64) 19171.63,
@@ -13165,6 +14262,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607286600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19177.35,
       (string) (len=4) "high": (float64) 19195.17,
@@ -13177,6 +14275,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607288400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19164.43,
       (string) (len=4) "high": (float64) 19180.96,
@@ -13189,6 +14288,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607290200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19247.64,
       (string) (len=4) "high": (float64) 19247.64,
@@ -13201,6 +14301,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607292000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19180.69,
       (string) (len=4) "high": (float64) 19255,
@@ -13213,6 +14314,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607293800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19142.47,
       (string) (len=4) "high": (float64) 19181.45,
@@ -13225,6 +14327,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607295600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19361.07,
       (string) (len=4) "high": (float64) 19430.25,
@@ -13237,6 +14340,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607297400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19375.6,
       (string) (len=4) "high": (float64) 19395,
@@ -13249,6 +14353,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607299200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19362.4,
       (string) (len=4) "high": (float64) 19432.57,
@@ -13261,6 +14366,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607301000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19327.29,
       (string) (len=4) "high": (float64) 19410,
@@ -13273,6 +14379,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607302800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19284.37,
       (string) (len=4) "high": (float64) 19357.6,
@@ -13285,6 +14392,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607304600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19304.23,
       (string) (len=4) "high": (float64) 19315.37,
@@ -13297,6 +14405,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607306400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19217.39,
       (string) (len=4) "high": (float64) 19314.32,
@@ -13309,6 +14418,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607308200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19215.63,
       (string) (len=4) "high": (float64) 19266.98,
@@ -13321,6 +14431,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607310000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19241.38,
       (string) (len=4) "high": (float64) 19261.72,
@@ -13333,6 +14444,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607311800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19294.77,
       (string) (len=4) "high": (float64) 19294.77,
@@ -13345,6 +14457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607313600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19259.17,
       (string) (len=4) "high": (float64) 19294.77,
@@ -13357,6 +14470,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607315400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19294.22,
       (string) (len=4) "high": (float64) 19317.47,
@@ -13369,6 +14483,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607317200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19306,
       (string) (len=4) "high": (float64) 19306,
@@ -13381,6 +14496,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607319000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19247.86,
       (string) (len=4) "high": (float64) 19306,
@@ -13393,6 +14509,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607320800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19338.82,
       (string) (len=4) "high": (float64) 19359.99,
@@ -13405,6 +14522,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607322600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19308.23,
       (string) (len=4) "high": (float64) 19338.83,
@@ -13417,6 +14535,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607324400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19334.33,
       (string) (len=4) "high": (float64) 19366.84,
@@ -13429,6 +14548,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607326200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19378.35,
       (string) (len=4) "high": (float64) 19399,
@@ -13441,6 +14561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607328000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19263.11,
       (string) (len=4) "high": (float64) 19390.32,
@@ -13453,6 +14574,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607329800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19258.28,
       (string) (len=4) "high": (float64) 19265.04,
@@ -13465,6 +14587,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607331600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19187.99,
       (string) (len=4) "high": (float64) 19261.39,
@@ -13477,6 +14600,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607333400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19217.79,
       (string) (len=4) "high": (float64) 19243.91,
@@ -13489,6 +14613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607335200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19238.98,
       (string) (len=4) "high": (float64) 19256.89,
@@ -13501,6 +14626,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607337000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19197.01,
       (string) (len=4) "high": (float64) 19244.33,
@@ -13513,6 +14639,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607338800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19203.34,
       (string) (len=4) "high": (float64) 19235.23,
@@ -13525,6 +14652,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607340600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19112.66,
       (string) (len=4) "high": (float64) 19210.62,
@@ -13537,6 +14665,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607342400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19200.77,
       (string) (len=4) "high": (float64) 19209.94,
@@ -13549,6 +14678,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607344200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19238.84,
       (string) (len=4) "high": (float64) 19247.74,
@@ -13561,6 +14691,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607346000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19194.71,
       (string) (len=4) "high": (float64) 19263.21,
@@ -13573,6 +14704,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607347800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19196.39,
       (string) (len=4) "high": (float64) 19236.82,
@@ -13585,6 +14717,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607349600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19218.43,
       (string) (len=4) "high": (float64) 19237.37,
@@ -13597,6 +14730,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607351400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19210.58,
       (string) (len=4) "high": (float64) 19231.21,
@@ -13609,6 +14743,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607353200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19252.96,
       (string) (len=4) "high": (float64) 19270.22,
@@ -13621,6 +14756,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607355000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19227.81,
       (string) (len=4) "high": (float64) 19265.46,
@@ -13633,6 +14769,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607356800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19253.49,
       (string) (len=4) "high": (float64) 19254.01,
@@ -13645,6 +14782,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607358600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19198.16,
       (string) (len=4) "high": (float64) 19251.67,
@@ -13657,6 +14795,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607360400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19188.79,
       (string) (len=4) "high": (float64) 19219.12,
@@ -13669,6 +14808,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607362200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19171.47,
       (string) (len=4) "high": (float64) 19189.11,
@@ -13681,6 +14821,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607364000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19005,
       (string) (len=4) "high": (float64) 19195.14,
@@ -13693,6 +14834,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607365800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18943.95,
       (string) (len=4) "high": (float64) 19027.62,
@@ -13705,6 +14847,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607367600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19019.72,
       (string) (len=4) "high": (float64) 19021.41,
@@ -13717,6 +14860,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607369400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18974.94,
       (string) (len=4) "high": (float64) 19046.92,
@@ -13729,6 +14873,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607371200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19024.44,
       (string) (len=4) "high": (float64) 19034.45,
@@ -13741,6 +14886,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607373000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19056.53,
       (string) (len=4) "high": (float64) 19063.43,
@@ -13753,6 +14899,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607374800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19125.34,
       (string) (len=4) "high": (float64) 19126,
@@ -13765,6 +14912,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607376600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19079.42,
       (string) (len=4) "high": (float64) 19125.63,
@@ -13777,6 +14925,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607378400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19078.28,
       (string) (len=4) "high": (float64) 19119.56,
@@ -13789,6 +14938,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607380200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19123.87,
       (string) (len=4) "high": (float64) 19125,
@@ -13801,6 +14951,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607382000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19179.39,
       (string) (len=4) "high": (float64) 19191.96,
@@ -13813,6 +14964,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607383800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19177.71,
       (string) (len=4) "high": (float64) 19229.08,
@@ -13825,6 +14977,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607385600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19173.88,
       (string) (len=4) "high": (float64) 19203.39,
@@ -13837,6 +14990,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607387400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19238.31,
       (string) (len=4) "high": (float64) 19242.43,
@@ -13849,6 +15003,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607389200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19208.38,
       (string) (len=4) "high": (float64) 19245,
@@ -13861,6 +15016,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607391000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19223.55,
       (string) (len=4) "high": (float64) 19229.26,
@@ -13873,6 +15029,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607392800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19184.88,
       (string) (len=4) "high": (float64) 19225,
@@ -13885,6 +15042,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607394600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19189.9,
       (string) (len=4) "high": (float64) 19200,
@@ -13897,6 +15055,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607396400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19150.56,
       (string) (len=4) "high": (float64) 19201.59,
@@ -13909,6 +15068,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607398200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19159.23,
       (string) (len=4) "high": (float64) 19188.55,
@@ -13921,6 +15081,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607400000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19205.79,
       (string) (len=4) "high": (float64) 19221.73,
@@ -13933,6 +15094,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607401800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19185.26,
       (string) (len=4) "high": (float64) 19212.77,
@@ -13945,6 +15107,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607403600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19213.13,
       (string) (len=4) "high": (float64) 19215,
@@ -13957,6 +15120,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607405400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19299.4,
       (string) (len=4) "high": (float64) 19299.41,
@@ -13969,6 +15133,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607407200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19162.22,
       (string) (len=4) "high": (float64) 19299.51,
@@ -13981,6 +15146,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607409000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19162.22,
       (string) (len=4) "high": (float64) 19189.92,
@@ -13993,6 +15159,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607410800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19167.96,
       (string) (len=4) "high": (float64) 19195.5,
@@ -14005,6 +15172,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607412600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19143.22,
       (string) (len=4) "high": (float64) 19186.49,
@@ -14017,6 +15185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607414400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19136.21,
       (string) (len=4) "high": (float64) 19169.13,
@@ -14029,6 +15198,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607416200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19067.48,
       (string) (len=4) "high": (float64) 19138.62,
@@ -14041,6 +15211,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607418000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19040.98,
       (string) (len=4) "high": (float64) 19104.09,
@@ -14053,6 +15224,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607419800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18798.24,
       (string) (len=4) "high": (float64) 19046.32,
@@ -14065,6 +15237,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607421600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18849,
       (string) (len=4) "high": (float64) 18887.89,
@@ -14077,6 +15250,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607423400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18815.62,
       (string) (len=4) "high": (float64) 18857.89,
@@ -14089,6 +15263,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607425200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18793.68,
       (string) (len=4) "high": (float64) 18875.25,
@@ -14101,6 +15276,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607427000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18770,
       (string) (len=4) "high": (float64) 18837.8,
@@ -14113,6 +15289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607428800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18765.42,
       (string) (len=4) "high": (float64) 18864.93,
@@ -14125,6 +15302,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607430600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18732.2,
       (string) (len=4) "high": (float64) 18770.33,
@@ -14137,6 +15315,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607432400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18885.25,
       (string) (len=4) "high": (float64) 18934.05,
@@ -14149,6 +15328,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607434200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18929.99,
       (string) (len=4) "high": (float64) 18958.1,
@@ -14161,6 +15341,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607436000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18939.71,
       (string) (len=4) "high": (float64) 18984.06,
@@ -14173,6 +15354,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607437800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18870.01,
       (string) (len=4) "high": (float64) 18961.73,
@@ -14185,6 +15367,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607439600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18833.82,
       (string) (len=4) "high": (float64) 18917.4,
@@ -14197,6 +15380,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607441400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18807.2,
       (string) (len=4) "high": (float64) 18874.48,
@@ -14209,6 +15393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607443200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18891.41,
       (string) (len=4) "high": (float64) 18900,
@@ -14221,6 +15406,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607445000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18834.45,
       (string) (len=4) "high": (float64) 18912.41,
@@ -14233,6 +15419,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607446800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18884.56,
       (string) (len=4) "high": (float64) 18895,
@@ -14245,6 +15432,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607448600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18925.42,
       (string) (len=4) "high": (float64) 18937.57,
@@ -14257,6 +15445,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607450400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18890.36,
       (string) (len=4) "high": (float64) 18925.42,
@@ -14269,6 +15458,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607452200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18820.42,
       (string) (len=4) "high": (float64) 18890.36,
@@ -14281,6 +15471,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607454000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18865.97,
       (string) (len=4) "high": (float64) 18889.03,
@@ -14293,6 +15484,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607455800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18786.88,
       (string) (len=4) "high": (float64) 18867.99,
@@ -14305,6 +15497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607457600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18742.59,
       (string) (len=4) "high": (float64) 18838.76,
@@ -14317,6 +15510,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607459400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18732.16,
       (string) (len=4) "high": (float64) 18784.1,
@@ -14329,6 +15523,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607461200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18761.79,
       (string) (len=4) "high": (float64) 18818.76,
@@ -14341,6 +15536,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607463000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18771.75,
       (string) (len=4) "high": (float64) 18794.08,
@@ -14353,6 +15549,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607464800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18699.81,
       (string) (len=4) "high": (float64) 18838.51,
@@ -14365,6 +15562,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607466600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18340.01,
       (string) (len=4) "high": (float64) 18710.98,
@@ -14377,6 +15575,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607468400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18289.52,
       (string) (len=4) "high": (float64) 18431,
@@ -14389,6 +15588,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607470200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18316.22,
       (string) (len=4) "high": (float64) 18398.49,
@@ -14401,6 +15601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607472000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18364.23,
       (string) (len=4) "high": (float64) 18368.49,
@@ -14413,6 +15614,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607473800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18165,
       (string) (len=4) "high": (float64) 18368.77,
@@ -14425,6 +15627,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607475600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18240.31,
       (string) (len=4) "high": (float64) 18275.14,
@@ -14437,6 +15640,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607477400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18208.34,
       (string) (len=4) "high": (float64) 18311.09,
@@ -14449,6 +15653,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607479200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18261.5,
       (string) (len=4) "high": (float64) 18283.63,
@@ -14461,6 +15666,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607481000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18278.13,
       (string) (len=4) "high": (float64) 18322.93,
@@ -14473,6 +15679,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607482800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18240,
       (string) (len=4) "high": (float64) 18307.98,
@@ -14485,6 +15692,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607484600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18294.55,
       (string) (len=4) "high": (float64) 18297.38,
@@ -14497,6 +15705,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607486400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18217.74,
       (string) (len=4) "high": (float64) 18297.41,
@@ -14509,6 +15718,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607488200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18155.68,
       (string) (len=4) "high": (float64) 18254.44,
@@ -14521,6 +15731,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607490000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18103.54,
       (string) (len=4) "high": (float64) 18196.3,
@@ -14533,6 +15744,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607491800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18206.88,
       (string) (len=4) "high": (float64) 18242.51,
@@ -14545,6 +15757,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607493600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18222.88,
       (string) (len=4) "high": (float64) 18270,
@@ -14557,6 +15770,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607495400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18210.94,
       (string) (len=4) "high": (float64) 18249.99,
@@ -14569,6 +15783,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607497200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18123,
       (string) (len=4) "high": (float64) 18241.51,
@@ -14581,6 +15796,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607499000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17925.2,
       (string) (len=4) "high": (float64) 18162.76,
@@ -14593,6 +15809,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607500800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17750,
       (string) (len=4) "high": (float64) 18048.65,
@@ -14605,6 +15822,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607502600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17949.84,
       (string) (len=4) "high": (float64) 17962.79,
@@ -14617,6 +15835,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607504400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18083.58,
       (string) (len=4) "high": (float64) 18095.53,
@@ -14629,6 +15848,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607506200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18035.33,
       (string) (len=4) "high": (float64) 18088.28,
@@ -14641,6 +15861,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607508000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18097.62,
       (string) (len=4) "high": (float64) 18135.89,
@@ -14653,6 +15874,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607509800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18225.19,
       (string) (len=4) "high": (float64) 18241.92,
@@ -14665,6 +15887,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607511600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18297.38,
       (string) (len=4) "high": (float64) 18398.54,
@@ -14677,6 +15900,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607513400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18253.93,
       (string) (len=4) "high": (float64) 18322.26,
@@ -14689,6 +15913,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607515200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18290.09,
       (string) (len=4) "high": (float64) 18377.11,
@@ -14701,6 +15926,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607517000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18237.44,
       (string) (len=4) "high": (float64) 18320.82,
@@ -14713,6 +15939,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607518800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18204.1,
       (string) (len=4) "high": (float64) 18286.65,
@@ -14725,6 +15952,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607520600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18492,
       (string) (len=4) "high": (float64) 18492,
@@ -14737,6 +15965,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607522400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18462.78,
       (string) (len=4) "high": (float64) 18529.93,
@@ -14749,6 +15978,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607524200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18465.14,
       (string) (len=4) "high": (float64) 18524.79,
@@ -14761,6 +15991,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607526000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18338.54,
       (string) (len=4) "high": (float64) 18474.13,
@@ -14773,6 +16004,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607527800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18345.9,
       (string) (len=4) "high": (float64) 18365.62,
@@ -14785,6 +16017,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607529600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18320.01,
       (string) (len=4) "high": (float64) 18353.58,
@@ -14797,6 +16030,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607531400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18387.92,
       (string) (len=4) "high": (float64) 18393.31,
@@ -14809,6 +16043,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607533200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18330.59,
       (string) (len=4) "high": (float64) 18438.47,
@@ -14821,6 +16056,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607535000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18297.55,
       (string) (len=4) "high": (float64) 18362.82,
@@ -14833,6 +16069,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607536800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18243.65,
       (string) (len=4) "high": (float64) 18346.01,
@@ -14845,6 +16082,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607538600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18188.51,
       (string) (len=4) "high": (float64) 18252.61,
@@ -14857,6 +16095,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607540400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18240.87,
       (string) (len=4) "high": (float64) 18266.86,
@@ -14869,6 +16108,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607542200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18255.14,
       (string) (len=4) "high": (float64) 18275,
@@ -14881,6 +16121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607544000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18258.35,
       (string) (len=4) "high": (float64) 18346.4,
@@ -14893,6 +16134,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607545800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18323.67,
       (string) (len=4) "high": (float64) 18361.08,
@@ -14905,6 +16147,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607547600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18435.71,
       (string) (len=4) "high": (float64) 18479.82,
@@ -14917,6 +16160,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607549400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18517.51,
       (string) (len=4) "high": (float64) 18540,
@@ -14929,6 +16173,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607551200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18538.72,
       (string) (len=4) "high": (float64) 18612.47,
@@ -14941,6 +16186,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607553000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18557.47,
       (string) (len=4) "high": (float64) 18581.66,
@@ -14953,6 +16199,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607554800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18599.44,
       (string) (len=4) "high": (float64) 18647.33,
@@ -14965,6 +16212,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607556600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18546.55,
       (string) (len=4) "high": (float64) 18614.73,
@@ -14977,6 +16225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607558400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18458.77,
       (string) (len=4) "high": (float64) 18556.42,
@@ -14989,6 +16238,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607560200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18434,
       (string) (len=4) "high": (float64) 18479.56,
@@ -15001,6 +16251,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607562000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18451.48,
       (string) (len=4) "high": (float64) 18494.96,
@@ -15013,6 +16264,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607563800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18434,
       (string) (len=4) "high": (float64) 18472.73,
@@ -15025,6 +16277,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607565600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18421.62,
       (string) (len=4) "high": (float64) 18489.08,
@@ -15037,6 +16290,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607567400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18385.11,
       (string) (len=4) "high": (float64) 18427.29,
@@ -15049,6 +16303,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607569200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18435.33,
       (string) (len=4) "high": (float64) 18467.4,
@@ -15061,6 +16316,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607571000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18410.62,
       (string) (len=4) "high": (float64) 18479.99,
@@ -15073,6 +16329,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607572800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18464.44,
       (string) (len=4) "high": (float64) 18496.21,
@@ -15085,6 +16342,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607574600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18419.25,
       (string) (len=4) "high": (float64) 18496.35,
@@ -15097,6 +16355,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607576400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18359.22,
       (string) (len=4) "high": (float64) 18418.29,
@@ -15109,6 +16368,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607578200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18372.25,
       (string) (len=4) "high": (float64) 18399.91,
@@ -15121,6 +16381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607580000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18299.79,
       (string) (len=4) "high": (float64) 18440.54,
@@ -15133,6 +16394,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607581800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18303.7,
       (string) (len=4) "high": (float64) 18381.19,
@@ -15145,6 +16407,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607583600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18352.45,
       (string) (len=4) "high": (float64) 18386.58,
@@ -15157,6 +16420,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607585400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18341.54,
       (string) (len=4) "high": (float64) 18391.35,
@@ -15169,6 +16433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607587200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18452.63,
       (string) (len=4) "high": (float64) 18470.59,
@@ -15181,6 +16446,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607589000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18441.75,
       (string) (len=4) "high": (float64) 18460.49,
@@ -15193,6 +16459,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607590800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18441.4,
       (string) (len=4) "high": (float64) 18447.92,
@@ -15205,6 +16472,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607592600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18238.91,
       (string) (len=4) "high": (float64) 18480,
@@ -15217,6 +16485,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607594400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18195.18,
       (string) (len=4) "high": (float64) 18281.07,
@@ -15229,6 +16498,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607596200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18139.24,
       (string) (len=4) "high": (float64) 18234.13,
@@ -15241,6 +16511,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607598000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18145.21,
       (string) (len=4) "high": (float64) 18253.72,
@@ -15253,6 +16524,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607599800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18189.99,
       (string) (len=4) "high": (float64) 18232.14,
@@ -15265,6 +16537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607601600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18241.78,
       (string) (len=4) "high": (float64) 18288.54,
@@ -15277,6 +16550,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607603400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18205.02,
       (string) (len=4) "high": (float64) 18257.63,
@@ -15289,6 +16563,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607605200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18117.44,
       (string) (len=4) "high": (float64) 18203.86,
@@ -15301,6 +16576,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607607000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18226.4,
       (string) (len=4) "high": (float64) 18238.85,
@@ -15313,6 +16589,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607608800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18055,
       (string) (len=4) "high": (float64) 18237.93,
@@ -15325,6 +16602,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607610600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18071.95,
       (string) (len=4) "high": (float64) 18109.08,
@@ -15337,6 +16615,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607612400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18014.83,
       (string) (len=4) "high": (float64) 18141.42,
@@ -15349,6 +16628,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607614200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18130.99,
       (string) (len=4) "high": (float64) 18140.31,
@@ -15361,6 +16641,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607616000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18149.81,
       (string) (len=4) "high": (float64) 18196.37,
@@ -15373,6 +16654,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607617800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18170.24,
       (string) (len=4) "high": (float64) 18222.04,
@@ -15385,6 +16667,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607619600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18089.86,
       (string) (len=4) "high": (float64) 18178.72,
@@ -15397,6 +16680,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607621400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18206.01,
       (string) (len=4) "high": (float64) 18213.37,
@@ -15409,6 +16693,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607623200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18260.82,
       (string) (len=4) "high": (float64) 18268.14,
@@ -15421,6 +16706,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607625000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18270.84,
       (string) (len=4) "high": (float64) 18314.39,
@@ -15433,6 +16719,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607626800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18276.97,
       (string) (len=4) "high": (float64) 18315.02,
@@ -15445,6 +16732,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607628600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18396.51,
       (string) (len=4) "high": (float64) 18400,
@@ -15457,6 +16745,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607630400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18412.69,
       (string) (len=4) "high": (float64) 18433.81,
@@ -15469,6 +16758,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607632200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18363.7,
       (string) (len=4) "high": (float64) 18412.69,
@@ -15481,6 +16771,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607634000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18373.68,
       (string) (len=4) "high": (float64) 18410.5,
@@ -15493,6 +16784,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607635800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18349.13,
       (string) (len=4) "high": (float64) 18387.19,
@@ -15505,6 +16797,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607637600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18340.37,
       (string) (len=4) "high": (float64) 18400,
@@ -15517,6 +16810,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607639400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18328.24,
       (string) (len=4) "high": (float64) 18366.55,
@@ -15529,6 +16823,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607641200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18341.8,
       (string) (len=4) "high": (float64) 18385,
@@ -15541,6 +16836,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607643000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18253.44,
       (string) (len=4) "high": (float64) 18340.92,
@@ -15553,6 +16849,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607644800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18112.67,
       (string) (len=4) "high": (float64) 18293.08,
@@ -15565,6 +16862,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607646600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18011.41,
       (string) (len=4) "high": (float64) 18145.91,
@@ -15577,6 +16875,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607648400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17902.59,
       (string) (len=4) "high": (float64) 18083.73,
@@ -15589,6 +16888,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607650200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17894.95,
       (string) (len=4) "high": (float64) 17988.56,
@@ -15601,6 +16901,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607652000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17987.85,
       (string) (len=4) "high": (float64) 18042.63,
@@ -15613,6 +16914,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607653800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17799.4,
       (string) (len=4) "high": (float64) 17996.68,
@@ -15625,6 +16927,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607655600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17930.11,
       (string) (len=4) "high": (float64) 17941.16,
@@ -15637,6 +16940,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607657400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17989.31,
       (string) (len=4) "high": (float64) 17994.34,
@@ -15649,6 +16953,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607659200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17966.5,
       (string) (len=4) "high": (float64) 18041.5,
@@ -15661,6 +16966,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607661000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17959,
       (string) (len=4) "high": (float64) 17994.16,
@@ -15673,6 +16979,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607662800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17907.05,
       (string) (len=4) "high": (float64) 18021.18,
@@ -15685,6 +16992,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607664600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17893.77,
       (string) (len=4) "high": (float64) 17943.86,
@@ -15697,6 +17005,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607666400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17842.7,
       (string) (len=4) "high": (float64) 17938.21,
@@ -15709,6 +17018,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607668200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17921.54,
       (string) (len=4) "high": (float64) 17966.71,
@@ -15721,6 +17031,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607670000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17791.26,
       (string) (len=4) "high": (float64) 17940.9,
@@ -15733,6 +17044,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607671800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17800,
       (string) (len=4) "high": (float64) 17828.2,
@@ -15745,6 +17057,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607673600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17942.05,
       (string) (len=4) "high": (float64) 17996,
@@ -15757,6 +17070,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607675400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17886.29,
       (string) (len=4) "high": (float64) 17948.98,
@@ -15769,6 +17083,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607677200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17826.38,
       (string) (len=4) "high": (float64) 17899.01,
@@ -15781,6 +17096,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607679000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17799,
       (string) (len=4) "high": (float64) 17869.54,
@@ -15793,6 +17109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607680800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17801.31,
       (string) (len=4) "high": (float64) 17825,
@@ -15805,6 +17122,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607682600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17741.9,
       (string) (len=4) "high": (float64) 17857.57,
@@ -15817,6 +17135,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607684400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17642.04,
       (string) (len=4) "high": (float64) 17741.9,
@@ -15829,6 +17148,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607686200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17639.93,
       (string) (len=4) "high": (float64) 17682.72,
@@ -15841,6 +17161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607688000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17794.07,
       (string) (len=4) "high": (float64) 17794.26,
@@ -15853,6 +17174,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607689800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17860,
       (string) (len=4) "high": (float64) 17909.76,
@@ -15865,6 +17187,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607691600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17863.49,
       (string) (len=4) "high": (float64) 17931.76,
@@ -15877,6 +17200,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607693400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17970.13,
       (string) (len=4) "high": (float64) 17981.8,
@@ -15889,6 +17213,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607695200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17971.78,
       (string) (len=4) "high": (float64) 18030.01,
@@ -15901,6 +17226,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607697000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18059.6,
       (string) (len=4) "high": (float64) 18072.95,
@@ -15913,6 +17239,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607698800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18060.91,
       (string) (len=4) "high": (float64) 18104.78,
@@ -15925,6 +17252,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607700600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18107.72,
       (string) (len=4) "high": (float64) 18135,
@@ -15937,6 +17265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607702400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18003,
       (string) (len=4) "high": (float64) 18115.05,
@@ -15949,6 +17278,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607704200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17976.88,
       (string) (len=4) "high": (float64) 18024.99,
@@ -15961,6 +17291,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607706000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17922.69,
       (string) (len=4) "high": (float64) 18002.87,
@@ -15973,6 +17304,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607707800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17986.22,
       (string) (len=4) "high": (float64) 18000,
@@ -15985,6 +17317,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607709600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17961.46,
       (string) (len=4) "high": (float64) 18033.25,
@@ -15997,6 +17330,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607711400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18042.9,
       (string) (len=4) "high": (float64) 18045.92,
@@ -16009,6 +17343,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607713200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18062.04,
       (string) (len=4) "high": (float64) 18091,
@@ -16021,6 +17356,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607715000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17970.96,
       (string) (len=4) "high": (float64) 18069.58,
@@ -16033,6 +17369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607716800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17952.86,
       (string) (len=4) "high": (float64) 18054.88,
@@ -16045,6 +17382,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607718600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17976.34,
       (string) (len=4) "high": (float64) 17993.76,
@@ -16057,6 +17395,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607720400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17965.46,
       (string) (len=4) "high": (float64) 18030.99,
@@ -16069,6 +17408,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607722200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18100.13,
       (string) (len=4) "high": (float64) 18125,
@@ -16081,6 +17421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607724000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18132.12,
       (string) (len=4) "high": (float64) 18181.61,
@@ -16093,6 +17434,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607725800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18135,
       (string) (len=4) "high": (float64) 18155.23,
@@ -16105,6 +17447,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607727600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18074.71,
       (string) (len=4) "high": (float64) 18150,
@@ -16117,6 +17460,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607729400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18042.15,
       (string) (len=4) "high": (float64) 18095.04,
@@ -16129,6 +17473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607731200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18289.02,
       (string) (len=4) "high": (float64) 18289.02,
@@ -16141,6 +17486,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607733000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18344.07,
       (string) (len=4) "high": (float64) 18369,
@@ -16153,6 +17499,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607734800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18312,
       (string) (len=4) "high": (float64) 18375,
@@ -16165,6 +17512,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607736600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18300.44,
       (string) (len=4) "high": (float64) 18336.19,
@@ -16177,6 +17525,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607738400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18322.04,
       (string) (len=4) "high": (float64) 18350,
@@ -16189,6 +17538,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607740200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18323.39,
       (string) (len=4) "high": (float64) 18366.59,
@@ -16201,6 +17551,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607742000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18292.14,
       (string) (len=4) "high": (float64) 18328.82,
@@ -16213,6 +17564,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607743800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18290.79,
       (string) (len=4) "high": (float64) 18345,
@@ -16225,6 +17577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607745600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18289.75,
       (string) (len=4) "high": (float64) 18313.45,
@@ -16237,6 +17590,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607747400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18375.17,
       (string) (len=4) "high": (float64) 18397.05,
@@ -16249,6 +17603,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607749200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18356.29,
       (string) (len=4) "high": (float64) 18399,
@@ -16261,6 +17616,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607751000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18329.41,
       (string) (len=4) "high": (float64) 18366.64,
@@ -16273,6 +17629,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607752800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18320.55,
       (string) (len=4) "high": (float64) 18372.75,
@@ -16285,6 +17642,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607754600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18314.92,
       (string) (len=4) "high": (float64) 18320.6,
@@ -16297,6 +17655,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607756400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18321.99,
       (string) (len=4) "high": (float64) 18357.51,
@@ -16309,6 +17668,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607758200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18394.94,
       (string) (len=4) "high": (float64) 18414.7,
@@ -16321,6 +17681,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607760000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18373.41,
       (string) (len=4) "high": (float64) 18460.28,
@@ -16333,6 +17694,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607761800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18384.39,
       (string) (len=4) "high": (float64) 18400.8,
@@ -16345,6 +17707,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607763600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18461.84,
       (string) (len=4) "high": (float64) 18477.77,
@@ -16357,6 +17720,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607765400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18434.01,
       (string) (len=4) "high": (float64) 18470.18,
@@ -16369,6 +17733,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607767200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18373.12,
       (string) (len=4) "high": (float64) 18459.6,
@@ -16381,6 +17746,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607769000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18383.65,
       (string) (len=4) "high": (float64) 18438.71,
@@ -16393,6 +17759,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607770800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18437.36,
       (string) (len=4) "high": (float64) 18453.19,
@@ -16405,6 +17772,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607772600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18509.5,
       (string) (len=4) "high": (float64) 18518.24,
@@ -16417,6 +17785,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607774400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18471.79,
       (string) (len=4) "high": (float64) 18530.72,
@@ -16429,6 +17798,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607776200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18447.23,
       (string) (len=4) "high": (float64) 18487.35,
@@ -16441,6 +17811,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607778000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18440.59,
       (string) (len=4) "high": (float64) 18447.42,
@@ -16453,6 +17824,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607779800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18405.01,
       (string) (len=4) "high": (float64) 18441.23,
@@ -16465,6 +17837,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607781600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18470,
       (string) (len=4) "high": (float64) 18477.99,
@@ -16477,6 +17850,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607783400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18379.42,
       (string) (len=4) "high": (float64) 18470.01,
@@ -16489,6 +17863,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607785200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18402.58,
       (string) (len=4) "high": (float64) 18411.81,
@@ -16501,6 +17876,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607787000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18405.73,
       (string) (len=4) "high": (float64) 18448.52,
@@ -16513,6 +17889,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607788800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18433.34,
       (string) (len=4) "high": (float64) 18440.1,
@@ -16525,6 +17902,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607790600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18406.28,
       (string) (len=4) "high": (float64) 18456.64,
@@ -16537,6 +17915,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607792400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18411.81,
       (string) (len=4) "high": (float64) 18429.43,
@@ -16549,6 +17928,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607794200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18490.63,
       (string) (len=4) "high": (float64) 18519.38,
@@ -16561,6 +17941,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607796000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18706.78,
       (string) (len=4) "high": (float64) 18748.84,
@@ -16573,6 +17954,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607797800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18699.08,
       (string) (len=4) "high": (float64) 18746.25,
@@ -16585,6 +17967,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607799600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18821,
       (string) (len=4) "high": (float64) 18855.55,
@@ -16597,6 +17980,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607801400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18811.28,
       (string) (len=4) "high": (float64) 18844.12,
@@ -16609,6 +17993,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607803200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18804.1,
       (string) (len=4) "high": (float64) 18844.43,
@@ -16621,6 +18006,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607805000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18785.37,
       (string) (len=4) "high": (float64) 18855,
@@ -16633,6 +18019,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607806800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18789.36,
       (string) (len=4) "high": (float64) 18842.82,
@@ -16645,6 +18032,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607808600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18807.24,
       (string) (len=4) "high": (float64) 18849.95,
@@ -16657,6 +18045,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607810400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18820.07,
       (string) (len=4) "high": (float64) 18835.87,
@@ -16669,6 +18058,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607812200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18886.49,
       (string) (len=4) "high": (float64) 18955.34,
@@ -16681,6 +18071,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607814000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18818.25,
       (string) (len=4) "high": (float64) 18895.13,
@@ -16693,6 +18084,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607815800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18821.28,
       (string) (len=4) "high": (float64) 18841.17,
@@ -16705,6 +18097,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607817600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18802.01,
       (string) (len=4) "high": (float64) 18880.28,
@@ -16717,6 +18110,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607819400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18770.81,
       (string) (len=4) "high": (float64) 18812.92,
@@ -16729,6 +18123,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607821200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18795.37,
       (string) (len=4) "high": (float64) 18810,
@@ -16741,6 +18136,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607823000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18811.76,
       (string) (len=4) "high": (float64) 18820.33,
@@ -16753,6 +18149,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607824800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18826.09,
       (string) (len=4) "high": (float64) 18827.32,
@@ -16765,6 +18162,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607826600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18826.87,
       (string) (len=4) "high": (float64) 18849.38,
@@ -16777,6 +18175,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607828400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18804.53,
       (string) (len=4) "high": (float64) 18845.12,
@@ -16789,6 +18188,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607830200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18798.99,
       (string) (len=4) "high": (float64) 18804.53,
@@ -16801,6 +18201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607832000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18831.69,
       (string) (len=4) "high": (float64) 18843.52,
@@ -16813,6 +18214,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607833800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18865,
       (string) (len=4) "high": (float64) 18894.63,
@@ -16825,6 +18227,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607835600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18925.97,
       (string) (len=4) "high": (float64) 18926.29,
@@ -16837,6 +18240,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607837400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18861.16,
       (string) (len=4) "high": (float64) 18949.99,
@@ -16849,6 +18253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607839200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18938.11,
       (string) (len=4) "high": (float64) 18942.44,
@@ -16861,6 +18266,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607841000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18981.34,
       (string) (len=4) "high": (float64) 19000,
@@ -16873,6 +18279,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607842800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19102.72,
       (string) (len=4) "high": (float64) 19153.45,
@@ -16885,6 +18292,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607844600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19245.42,
       (string) (len=4) "high": (float64) 19290,
@@ -16897,6 +18305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607846400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19204.39,
       (string) (len=4) "high": (float64) 19305,
@@ -16909,6 +18318,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607848200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19245.75,
       (string) (len=4) "high": (float64) 19256.89,
@@ -16921,6 +18331,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607850000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19206,
       (string) (len=4) "high": (float64) 19255.97,
@@ -16933,6 +18344,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607851800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19263.91,
       (string) (len=4) "high": (float64) 19304.99,
@@ -16945,6 +18357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607853600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19299.79,
       (string) (len=4) "high": (float64) 19365.13,
@@ -16957,6 +18370,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607855400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19279.95,
       (string) (len=4) "high": (float64) 19349.13,
@@ -16969,6 +18383,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607857200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19268.76,
       (string) (len=4) "high": (float64) 19296.07,
@@ -16981,6 +18396,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607859000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19326.7,
       (string) (len=4) "high": (float64) 19349.36,
@@ -16993,6 +18409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607860800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19344.88,
       (string) (len=4) "high": (float64) 19388,
@@ -17005,6 +18422,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607862600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19354.39,
       (string) (len=4) "high": (float64) 19410,
@@ -17017,6 +18435,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607864400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19369.17,
       (string) (len=4) "high": (float64) 19421.03,
@@ -17029,6 +18448,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607866200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19332.84,
       (string) (len=4) "high": (float64) 19369.17,
@@ -17041,6 +18461,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607868000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19303.22,
       (string) (len=4) "high": (float64) 19368.62,
@@ -17053,6 +18474,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607869800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19299.99,
       (string) (len=4) "high": (float64) 19314.14,
@@ -17065,6 +18487,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607871600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19152.44,
       (string) (len=4) "high": (float64) 19339.97,
@@ -17077,6 +18500,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607873400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19216.85,
       (string) (len=4) "high": (float64) 19220.61,
@@ -17089,6 +18513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607875200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19337.38,
       (string) (len=4) "high": (float64) 19386.15,
@@ -17101,6 +18526,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607877000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19327.43,
       (string) (len=4) "high": (float64) 19372.79,
@@ -17113,6 +18539,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607878800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19246.66,
       (string) (len=4) "high": (float64) 19334.99,
@@ -17125,6 +18552,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607880600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19271.03,
       (string) (len=4) "high": (float64) 19273,
@@ -17137,6 +18565,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607882400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19205.8,
       (string) (len=4) "high": (float64) 19271.02,
@@ -17149,6 +18578,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607884200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19178.48,
       (string) (len=4) "high": (float64) 19229.99,
@@ -17161,6 +18591,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607886000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19190.37,
       (string) (len=4) "high": (float64) 19200,
@@ -17173,6 +18604,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607887800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19185.2,
       (string) (len=4) "high": (float64) 19219,
@@ -17185,6 +18617,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607889600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19115.01,
       (string) (len=4) "high": (float64) 19184.35,
@@ -17197,6 +18630,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607891400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19150,
       (string) (len=4) "high": (float64) 19169.49,
@@ -17209,6 +18643,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607893200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19188.25,
       (string) (len=4) "high": (float64) 19218.67,
@@ -17221,6 +18656,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607895000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19181.85,
       (string) (len=4) "high": (float64) 19195.65,
@@ -17233,6 +18669,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607896800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18995.32,
       (string) (len=4) "high": (float64) 19185.56,
@@ -17245,6 +18682,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607898600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19111.8,
       (string) (len=4) "high": (float64) 19121.79,
@@ -17257,6 +18695,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607900400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19179.33,
       (string) (len=4) "high": (float64) 19217.62,
@@ -17269,6 +18708,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607902200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19166.65,
       (string) (len=4) "high": (float64) 19183.41,
@@ -17281,6 +18721,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607904000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19083.66,
       (string) (len=4) "high": (float64) 19166.65,
@@ -17293,6 +18734,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607905800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19049.02,
       (string) (len=4) "high": (float64) 19105.09,
@@ -17305,6 +18747,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607907600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19093,
       (string) (len=4) "high": (float64) 19098.16,

--- a/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()
+++ b/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()
@@ -1,7 +1,7 @@
 ([]observations.Observation) (len=1443) {
   (observations.Observation) {
     Time: (int64) 1605312000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16254.51,
       (string) (len=4) "high": (float64) 16339.6,
       (string) (len=3) "low": (float64) 16240,
@@ -13,7 +13,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605313800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16305,
       (string) (len=4) "high": (float64) 16305,
       (string) (len=3) "low": (float64) 16248.6,
@@ -25,7 +25,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605315600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16222.16,
       (string) (len=4) "high": (float64) 16303.88,
       (string) (len=3) "low": (float64) 16210.99,
@@ -37,7 +37,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605317400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16214.15,
       (string) (len=4) "high": (float64) 16246.92,
       (string) (len=3) "low": (float64) 16200.01,
@@ -49,7 +49,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605319200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16223.08,
       (string) (len=4) "high": (float64) 16234,
       (string) (len=3) "low": (float64) 16175.62,
@@ -61,7 +61,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605321000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16185.68,
       (string) (len=4) "high": (float64) 16247.6,
       (string) (len=3) "low": (float64) 16168.45,
@@ -73,7 +73,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605322800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16202.24,
       (string) (len=4) "high": (float64) 16218.42,
       (string) (len=3) "low": (float64) 16165.15,
@@ -85,7 +85,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605324600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16194.21,
       (string) (len=4) "high": (float64) 16206.58,
       (string) (len=3) "low": (float64) 16155.95,
@@ -97,7 +97,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605326400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16159.4,
       (string) (len=4) "high": (float64) 16208.45,
       (string) (len=3) "low": (float64) 16122,
@@ -109,7 +109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605328200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16152.36,
       (string) (len=4) "high": (float64) 16170.29,
       (string) (len=3) "low": (float64) 16109.64,
@@ -121,7 +121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605330000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16100.84,
       (string) (len=4) "high": (float64) 16148.09,
       (string) (len=3) "low": (float64) 16070,
@@ -133,7 +133,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605331800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16180.01,
       (string) (len=4) "high": (float64) 16185.85,
       (string) (len=3) "low": (float64) 16095.87,
@@ -145,7 +145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605333600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16191.84,
       (string) (len=4) "high": (float64) 16223.37,
       (string) (len=3) "low": (float64) 16173.95,
@@ -157,7 +157,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605335400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16188.67,
       (string) (len=4) "high": (float64) 16206.85,
       (string) (len=3) "low": (float64) 16155.71,
@@ -169,7 +169,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605337200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16061.94,
       (string) (len=4) "high": (float64) 16201.83,
       (string) (len=3) "low": (float64) 16050,
@@ -181,7 +181,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605339000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16102.09,
       (string) (len=4) "high": (float64) 16114.1,
       (string) (len=3) "low": (float64) 16040.88,
@@ -193,7 +193,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605340800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15885.37,
       (string) (len=4) "high": (float64) 16140.01,
       (string) (len=3) "low": (float64) 15876.22,
@@ -205,7 +205,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605342600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15976.37,
       (string) (len=4) "high": (float64) 15979.96,
       (string) (len=3) "low": (float64) 15850.01,
@@ -217,7 +217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605344400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15906.38,
       (string) (len=4) "high": (float64) 15976.38,
       (string) (len=3) "low": (float64) 15866.91,
@@ -229,7 +229,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605346200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15805,
       (string) (len=4) "high": (float64) 15906.38,
       (string) (len=3) "low": (float64) 15770.27,
@@ -241,7 +241,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605348000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15935.31,
       (string) (len=4) "high": (float64) 15942.46,
       (string) (len=3) "low": (float64) 15752.64,
@@ -253,7 +253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605349800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15867.22,
       (string) (len=4) "high": (float64) 15957.48,
       (string) (len=3) "low": (float64) 15841.46,
@@ -265,7 +265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605351600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15930,
       (string) (len=4) "high": (float64) 15936.91,
       (string) (len=3) "low": (float64) 15832.21,
@@ -277,7 +277,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605353400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15945.38,
       (string) (len=4) "high": (float64) 15956.04,
       (string) (len=3) "low": (float64) 15900,
@@ -289,7 +289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605355200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15871.4,
       (string) (len=4) "high": (float64) 15948.1,
       (string) (len=3) "low": (float64) 15852.84,
@@ -301,7 +301,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605357000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15925.01,
       (string) (len=4) "high": (float64) 15933.82,
       (string) (len=3) "low": (float64) 15852.46,
@@ -313,7 +313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605358800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15936.47,
       (string) (len=4) "high": (float64) 15937.77,
       (string) (len=3) "low": (float64) 15867.26,
@@ -325,7 +325,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605360600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15944.34,
       (string) (len=4) "high": (float64) 15953.61,
       (string) (len=3) "low": (float64) 15903.74,
@@ -337,7 +337,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605362400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16040.28,
       (string) (len=4) "high": (float64) 16046.36,
       (string) (len=3) "low": (float64) 15944.34,
@@ -349,7 +349,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605364200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16026.12,
       (string) (len=4) "high": (float64) 16072.83,
       (string) (len=3) "low": (float64) 16004.28,
@@ -361,7 +361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605366000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16010.37,
       (string) (len=4) "high": (float64) 16046.55,
       (string) (len=3) "low": (float64) 15967.58,
@@ -373,7 +373,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605367800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15966.15,
       (string) (len=4) "high": (float64) 16021.39,
       (string) (len=3) "low": (float64) 15943.27,
@@ -385,7 +385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605369600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16013.58,
       (string) (len=4) "high": (float64) 16041.67,
       (string) (len=3) "low": (float64) 15940.01,
@@ -397,7 +397,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605371400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15865.37,
       (string) (len=4) "high": (float64) 16015.21,
       (string) (len=3) "low": (float64) 15837.72,
@@ -409,7 +409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605373200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15877.48,
       (string) (len=4) "high": (float64) 15893.54,
       (string) (len=3) "low": (float64) 15708.24,
@@ -421,7 +421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605375000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15922.8,
       (string) (len=4) "high": (float64) 15942.81,
       (string) (len=3) "low": (float64) 15872.03,
@@ -433,7 +433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605376800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15936.68,
       (string) (len=4) "high": (float64) 15968.98,
       (string) (len=3) "low": (float64) 15886.98,
@@ -445,7 +445,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605378600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15915.01,
       (string) (len=4) "high": (float64) 15950,
       (string) (len=3) "low": (float64) 15903.79,
@@ -457,7 +457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605380400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15898.93,
       (string) (len=4) "high": (float64) 15932.52,
       (string) (len=3) "low": (float64) 15879.07,
@@ -469,7 +469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605382200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15900.72,
       (string) (len=4) "high": (float64) 15919.19,
       (string) (len=3) "low": (float64) 15868.29,
@@ -481,7 +481,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605384000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15930.69,
       (string) (len=4) "high": (float64) 15943.49,
       (string) (len=3) "low": (float64) 15870.25,
@@ -493,7 +493,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605385800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16009.69,
       (string) (len=4) "high": (float64) 16019.41,
       (string) (len=3) "low": (float64) 15926.08,
@@ -505,7 +505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605387600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16007.74,
       (string) (len=4) "high": (float64) 16040,
       (string) (len=3) "low": (float64) 15998.43,
@@ -517,7 +517,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605389400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16009.52,
       (string) (len=4) "high": (float64) 16050,
       (string) (len=3) "low": (float64) 15991.08,
@@ -529,7 +529,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605391200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16027.35,
       (string) (len=4) "high": (float64) 16051.63,
       (string) (len=3) "low": (float64) 16004.12,
@@ -541,7 +541,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605393000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16051.89,
       (string) (len=4) "high": (float64) 16051.89,
       (string) (len=3) "low": (float64) 15975,
@@ -553,7 +553,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605394800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16107.01,
       (string) (len=4) "high": (float64) 16161.51,
       (string) (len=3) "low": (float64) 16051.88,
@@ -565,7 +565,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605396600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16082.01,
       (string) (len=4) "high": (float64) 16132.61,
       (string) (len=3) "low": (float64) 16078.02,
@@ -577,7 +577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605398400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16092.07,
       (string) (len=4) "high": (float64) 16123.67,
       (string) (len=3) "low": (float64) 16080,
@@ -589,7 +589,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605400200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16059.01,
       (string) (len=4) "high": (float64) 16098.21,
       (string) (len=3) "low": (float64) 16055.96,
@@ -601,7 +601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605402000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16005.24,
       (string) (len=4) "high": (float64) 16094.12,
       (string) (len=3) "low": (float64) 15938.54,
@@ -613,7 +613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605403800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15998.38,
       (string) (len=4) "high": (float64) 16027.06,
       (string) (len=3) "low": (float64) 15980.01,
@@ -625,7 +625,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605405600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16005.95,
       (string) (len=4) "high": (float64) 16047.56,
       (string) (len=3) "low": (float64) 15951,
@@ -637,7 +637,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605407400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15998.75,
       (string) (len=4) "high": (float64) 16014.43,
       (string) (len=3) "low": (float64) 15966.02,
@@ -649,7 +649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605409200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15930,
       (string) (len=4) "high": (float64) 16002.34,
       (string) (len=3) "low": (float64) 15891.03,
@@ -661,7 +661,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605411000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15946.09,
       (string) (len=4) "high": (float64) 15950.79,
       (string) (len=3) "low": (float64) 15886.54,
@@ -673,7 +673,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605412800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15967.64,
       (string) (len=4) "high": (float64) 15973.43,
       (string) (len=3) "low": (float64) 15895.22,
@@ -685,7 +685,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605414600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15949.05,
       (string) (len=4) "high": (float64) 15968.58,
       (string) (len=3) "low": (float64) 15923.65,
@@ -697,7 +697,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605416400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16007.18,
       (string) (len=4) "high": (float64) 16011.94,
       (string) (len=3) "low": (float64) 15949.05,
@@ -709,7 +709,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605418200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16033.32,
       (string) (len=4) "high": (float64) 16033.33,
       (string) (len=3) "low": (float64) 16005.51,
@@ -721,7 +721,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605420000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16051.81,
       (string) (len=4) "high": (float64) 16055.5,
       (string) (len=3) "low": (float64) 16006.2,
@@ -733,7 +733,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605421800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16069.26,
       (string) (len=4) "high": (float64) 16097.57,
       (string) (len=3) "low": (float64) 16045.8,
@@ -745,7 +745,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605423600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16046.17,
       (string) (len=4) "high": (float64) 16111.68,
       (string) (len=3) "low": (float64) 16040.01,
@@ -757,7 +757,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605425400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16045.93,
       (string) (len=4) "high": (float64) 16051.32,
       (string) (len=3) "low": (float64) 16016.01,
@@ -769,7 +769,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605427200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16146.63,
       (string) (len=4) "high": (float64) 16153.4,
       (string) (len=3) "low": (float64) 16045.31,
@@ -781,7 +781,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605429000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16135.46,
       (string) (len=4) "high": (float64) 16175.6,
       (string) (len=3) "low": (float64) 16100,
@@ -793,7 +793,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605430800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16109.67,
       (string) (len=4) "high": (float64) 16143.95,
       (string) (len=3) "low": (float64) 16077.17,
@@ -805,7 +805,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605432600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16082.41,
       (string) (len=4) "high": (float64) 16111.89,
       (string) (len=3) "low": (float64) 16054.16,
@@ -817,7 +817,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605434400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15999.88,
       (string) (len=4) "high": (float64) 16107.1,
       (string) (len=3) "low": (float64) 15985.18,
@@ -829,7 +829,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605436200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16007.41,
       (string) (len=4) "high": (float64) 16033.07,
       (string) (len=3) "low": (float64) 15979.82,
@@ -841,7 +841,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605438000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16069.91,
       (string) (len=4) "high": (float64) 16080.52,
       (string) (len=3) "low": (float64) 15950.6,
@@ -853,7 +853,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605439800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15972.08,
       (string) (len=4) "high": (float64) 16112.36,
       (string) (len=3) "low": (float64) 15962.56,
@@ -865,7 +865,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605441600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16047.88,
       (string) (len=4) "high": (float64) 16081.16,
       (string) (len=3) "low": (float64) 15950.37,
@@ -877,7 +877,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605443400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15993.78,
       (string) (len=4) "high": (float64) 16082.94,
       (string) (len=3) "low": (float64) 15990.28,
@@ -889,7 +889,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605445200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16048.49,
       (string) (len=4) "high": (float64) 16065.74,
       (string) (len=3) "low": (float64) 15969.86,
@@ -901,7 +901,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605447000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16062.34,
       (string) (len=4) "high": (float64) 16094,
       (string) (len=3) "low": (float64) 16031.94,
@@ -913,7 +913,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605448800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16090.62,
       (string) (len=4) "high": (float64) 16122.97,
       (string) (len=3) "low": (float64) 16040.48,
@@ -925,7 +925,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605450600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16064.02,
       (string) (len=4) "high": (float64) 16102.73,
       (string) (len=3) "low": (float64) 16040.39,
@@ -937,7 +937,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605452400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16054,
       (string) (len=4) "high": (float64) 16087.57,
       (string) (len=3) "low": (float64) 16046.6,
@@ -949,7 +949,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605454200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16041.73,
       (string) (len=4) "high": (float64) 16055.56,
       (string) (len=3) "low": (float64) 16011.1,
@@ -961,7 +961,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605456000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15985.29,
       (string) (len=4) "high": (float64) 16079.39,
       (string) (len=3) "low": (float64) 15970,
@@ -973,7 +973,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605457800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16020.01,
       (string) (len=4) "high": (float64) 16025.96,
       (string) (len=3) "low": (float64) 15978.07,
@@ -985,7 +985,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605459600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15997.23,
       (string) (len=4) "high": (float64) 16020.01,
       (string) (len=3) "low": (float64) 15980,
@@ -997,7 +997,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605461400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15900.01,
       (string) (len=4) "high": (float64) 15996.5,
       (string) (len=3) "low": (float64) 15890,
@@ -1009,7 +1009,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605463200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15940.01,
       (string) (len=4) "high": (float64) 15959.2,
       (string) (len=3) "low": (float64) 15861.79,
@@ -1021,7 +1021,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605465000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15916.83,
       (string) (len=4) "high": (float64) 15948,
       (string) (len=3) "low": (float64) 15905.66,
@@ -1033,7 +1033,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605466800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15928.17,
       (string) (len=4) "high": (float64) 15949.75,
       (string) (len=3) "low": (float64) 15871,
@@ -1045,7 +1045,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605468600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15882.05,
       (string) (len=4) "high": (float64) 15928.35,
       (string) (len=3) "low": (float64) 15870,
@@ -1057,7 +1057,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605470400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15832.86,
       (string) (len=4) "high": (float64) 15900,
       (string) (len=3) "low": (float64) 15825.01,
@@ -1069,7 +1069,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605472200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15858.88,
       (string) (len=4) "high": (float64) 15880.01,
       (string) (len=3) "low": (float64) 15820.51,
@@ -1081,7 +1081,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605474000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15888.93,
       (string) (len=4) "high": (float64) 15919.43,
       (string) (len=3) "low": (float64) 15840,
@@ -1093,7 +1093,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605475800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15856.67,
       (string) (len=4) "high": (float64) 15908,
       (string) (len=3) "low": (float64) 15846.01,
@@ -1105,7 +1105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605477600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15845.29,
       (string) (len=4) "high": (float64) 15864.07,
       (string) (len=3) "low": (float64) 15796.09,
@@ -1117,7 +1117,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605479400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15939.93,
       (string) (len=4) "high": (float64) 15978,
       (string) (len=3) "low": (float64) 15844.24,
@@ -1129,7 +1129,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605481200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15996.76,
       (string) (len=4) "high": (float64) 16021.75,
       (string) (len=3) "low": (float64) 15939.93,
@@ -1141,7 +1141,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605483000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15966.89,
       (string) (len=4) "high": (float64) 16018.57,
       (string) (len=3) "low": (float64) 15956.93,
@@ -1153,7 +1153,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605484800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15909.22,
       (string) (len=4) "high": (float64) 15970,
       (string) (len=3) "low": (float64) 15891.46,
@@ -1165,7 +1165,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605486600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15989.99,
       (string) (len=4) "high": (float64) 15992.17,
       (string) (len=3) "low": (float64) 15879,
@@ -1177,7 +1177,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605488400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15990.93,
       (string) (len=4) "high": (float64) 16055.63,
       (string) (len=3) "low": (float64) 15982.72,
@@ -1189,7 +1189,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605490200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15959.5,
       (string) (len=4) "high": (float64) 16020.64,
       (string) (len=3) "low": (float64) 15952.49,
@@ -1201,7 +1201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605492000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15967.68,
       (string) (len=4) "high": (float64) 16015,
       (string) (len=3) "low": (float64) 15959.49,
@@ -1213,7 +1213,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605493800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15946.27,
       (string) (len=4) "high": (float64) 15977.55,
       (string) (len=3) "low": (float64) 15939.84,
@@ -1225,7 +1225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605495600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 15989.39,
       (string) (len=4) "high": (float64) 15994.11,
       (string) (len=3) "low": (float64) 15946.26,
@@ -1237,7 +1237,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605497400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16020.98,
       (string) (len=4) "high": (float64) 16053.93,
       (string) (len=3) "low": (float64) 15989.38,
@@ -1249,7 +1249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605499200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16032.84,
       (string) (len=4) "high": (float64) 16050,
       (string) (len=3) "low": (float64) 15995.3,
@@ -1261,7 +1261,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605501000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16045.3,
       (string) (len=4) "high": (float64) 16048.24,
       (string) (len=3) "low": (float64) 15995.89,
@@ -1273,7 +1273,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605502800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16133.96,
       (string) (len=4) "high": (float64) 16149.63,
       (string) (len=3) "low": (float64) 16046.96,
@@ -1285,7 +1285,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605504600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16125.97,
       (string) (len=4) "high": (float64) 16150.99,
       (string) (len=3) "low": (float64) 16101.56,
@@ -1297,7 +1297,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605506400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16217.32,
       (string) (len=4) "high": (float64) 16244.95,
       (string) (len=3) "low": (float64) 16123.12,
@@ -1309,7 +1309,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605508200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16250.01,
       (string) (len=4) "high": (float64) 16260.99,
       (string) (len=3) "low": (float64) 16196.65,
@@ -1321,7 +1321,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605510000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16254,
       (string) (len=4) "high": (float64) 16300,
       (string) (len=3) "low": (float64) 16219.28,
@@ -1333,7 +1333,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605511800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16254.69,
       (string) (len=4) "high": (float64) 16277.53,
       (string) (len=3) "low": (float64) 16238.81,
@@ -1345,7 +1345,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605513600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16250.06,
       (string) (len=4) "high": (float64) 16286.27,
       (string) (len=3) "low": (float64) 16228.74,
@@ -1357,7 +1357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605515400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16225.04,
       (string) (len=4) "high": (float64) 16270,
       (string) (len=3) "low": (float64) 16219.28,
@@ -1369,7 +1369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605517200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16204.65,
       (string) (len=4) "high": (float64) 16248.83,
       (string) (len=3) "low": (float64) 16191.92,
@@ -1381,7 +1381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605519000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16237.63,
       (string) (len=4) "high": (float64) 16237.63,
       (string) (len=3) "low": (float64) 16181.75,
@@ -1393,7 +1393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605520800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16345,
       (string) (len=4) "high": (float64) 16345,
       (string) (len=3) "low": (float64) 16225.66,
@@ -1405,7 +1405,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605522600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16392.89,
       (string) (len=4) "high": (float64) 16392.89,
       (string) (len=3) "low": (float64) 16292.2,
@@ -1417,7 +1417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605524400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16383.44,
       (string) (len=4) "high": (float64) 16398,
       (string) (len=3) "low": (float64) 16337.8,
@@ -1429,7 +1429,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605526200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16232.03,
       (string) (len=4) "high": (float64) 16383.44,
       (string) (len=3) "low": (float64) 16231.12,
@@ -1441,7 +1441,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605528000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16304.38,
       (string) (len=4) "high": (float64) 16313.59,
       (string) (len=3) "low": (float64) 16229.69,
@@ -1453,7 +1453,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605529800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16320.34,
       (string) (len=4) "high": (float64) 16320.34,
       (string) (len=3) "low": (float64) 16269.99,
@@ -1465,7 +1465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605531600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16305.91,
       (string) (len=4) "high": (float64) 16352.06,
       (string) (len=3) "low": (float64) 16301.18,
@@ -1477,7 +1477,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605533400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16326.95,
       (string) (len=4) "high": (float64) 16380.99,
       (string) (len=3) "low": (float64) 16302.04,
@@ -1489,7 +1489,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605535200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16415.9,
       (string) (len=4) "high": (float64) 16422,
       (string) (len=3) "low": (float64) 16326.95,
@@ -1501,7 +1501,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605537000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16409.16,
       (string) (len=4) "high": (float64) 16447,
       (string) (len=3) "low": (float64) 16366.05,
@@ -1513,7 +1513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605538800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16410,
       (string) (len=4) "high": (float64) 16439,
       (string) (len=3) "low": (float64) 16354.79,
@@ -1525,7 +1525,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605540600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16463.62,
       (string) (len=4) "high": (float64) 16476,
       (string) (len=3) "low": (float64) 16390.48,
@@ -1537,7 +1537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605542400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16608.68,
       (string) (len=4) "high": (float64) 16639.66,
       (string) (len=3) "low": (float64) 16448.44,
@@ -1549,7 +1549,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605544200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16578.83,
       (string) (len=4) "high": (float64) 16660,
       (string) (len=3) "low": (float64) 16565.58,
@@ -1561,7 +1561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605546000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16747.99,
       (string) (len=4) "high": (float64) 16748,
       (string) (len=3) "low": (float64) 16578.24,
@@ -1573,7 +1573,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605547800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16695,
       (string) (len=4) "high": (float64) 16777,
       (string) (len=3) "low": (float64) 16681.8,
@@ -1585,7 +1585,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605549600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16691.26,
       (string) (len=4) "high": (float64) 16761.7,
       (string) (len=3) "low": (float64) 16652.51,
@@ -1597,7 +1597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605551400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16710,
       (string) (len=4) "high": (float64) 16749.42,
       (string) (len=3) "low": (float64) 16667.03,
@@ -1609,7 +1609,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605553200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16842.6,
       (string) (len=4) "high": (float64) 16859.95,
       (string) (len=3) "low": (float64) 16682.25,
@@ -1621,7 +1621,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605555000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16797.62,
       (string) (len=4) "high": (float64) 16842.61,
       (string) (len=3) "low": (float64) 16766.52,
@@ -1633,7 +1633,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605556800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16854.77,
       (string) (len=4) "high": (float64) 16857.73,
       (string) (len=3) "low": (float64) 16767.14,
@@ -1645,7 +1645,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605558600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16839.44,
       (string) (len=4) "high": (float64) 16857.98,
       (string) (len=3) "low": (float64) 16774.01,
@@ -1657,7 +1657,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605560400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16821.15,
       (string) (len=4) "high": (float64) 16892,
       (string) (len=3) "low": (float64) 16785,
@@ -1669,7 +1669,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605562200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16705.77,
       (string) (len=4) "high": (float64) 16821.15,
       (string) (len=3) "low": (float64) 16587.84,
@@ -1681,7 +1681,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605564000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16676.41,
       (string) (len=4) "high": (float64) 16760.77,
       (string) (len=3) "low": (float64) 16648.57,
@@ -1693,7 +1693,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605565800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16720.81,
       (string) (len=4) "high": (float64) 16794.18,
       (string) (len=3) "low": (float64) 16670.98,
@@ -1705,7 +1705,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605567600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16783.13,
       (string) (len=4) "high": (float64) 16798,
       (string) (len=3) "low": (float64) 16720.81,
@@ -1717,7 +1717,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605569400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16726.64,
       (string) (len=4) "high": (float64) 16784.25,
       (string) (len=3) "low": (float64) 16703.06,
@@ -1729,7 +1729,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605571200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16764.55,
       (string) (len=4) "high": (float64) 16772.43,
       (string) (len=3) "low": (float64) 16700,
@@ -1741,7 +1741,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605573000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16823.64,
       (string) (len=4) "high": (float64) 16844,
       (string) (len=3) "low": (float64) 16761.19,
@@ -1753,7 +1753,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605574800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16740.43,
       (string) (len=4) "high": (float64) 16823.63,
       (string) (len=3) "low": (float64) 16738,
@@ -1765,7 +1765,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605576600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16706.79,
       (string) (len=4) "high": (float64) 16762.06,
       (string) (len=3) "low": (float64) 16690,
@@ -1777,7 +1777,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605578400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16738.11,
       (string) (len=4) "high": (float64) 16767.38,
       (string) (len=3) "low": (float64) 16700.9,
@@ -1789,7 +1789,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605580200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16694.45,
       (string) (len=4) "high": (float64) 16738.72,
       (string) (len=3) "low": (float64) 16650,
@@ -1801,7 +1801,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605582000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16619.63,
       (string) (len=4) "high": (float64) 16722.53,
       (string) (len=3) "low": (float64) 16600,
@@ -1813,7 +1813,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605583800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16590.01,
       (string) (len=4) "high": (float64) 16650.01,
       (string) (len=3) "low": (float64) 16589.53,
@@ -1825,7 +1825,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605585600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16659.14,
       (string) (len=4) "high": (float64) 16676.25,
       (string) (len=3) "low": (float64) 16575.42,
@@ -1837,7 +1837,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605587400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16686.59,
       (string) (len=4) "high": (float64) 16690,
       (string) (len=3) "low": (float64) 16639.43,
@@ -1849,7 +1849,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605589200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16635.22,
       (string) (len=4) "high": (float64) 16686.59,
       (string) (len=3) "low": (float64) 16632.67,
@@ -1861,7 +1861,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605591000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16634,
       (string) (len=4) "high": (float64) 16685,
       (string) (len=3) "low": (float64) 16614,
@@ -1873,7 +1873,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605592800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16672.23,
       (string) (len=4) "high": (float64) 16675.75,
       (string) (len=3) "low": (float64) 16595.07,
@@ -1885,7 +1885,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605594600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16637.63,
       (string) (len=4) "high": (float64) 16684.68,
       (string) (len=3) "low": (float64) 16637.63,
@@ -1897,7 +1897,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605596400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16744.45,
       (string) (len=4) "high": (float64) 16762.77,
       (string) (len=3) "low": (float64) 16630,
@@ -1909,7 +1909,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605598200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16756.02,
       (string) (len=4) "high": (float64) 16790,
       (string) (len=3) "low": (float64) 16724.12,
@@ -1921,7 +1921,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605600000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16735.46,
       (string) (len=4) "high": (float64) 16797.82,
       (string) (len=3) "low": (float64) 16704.58,
@@ -1933,7 +1933,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605601800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16712.24,
       (string) (len=4) "high": (float64) 16750,
       (string) (len=3) "low": (float64) 16700.14,
@@ -1945,7 +1945,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605603600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16683.86,
       (string) (len=4) "high": (float64) 16757.57,
       (string) (len=3) "low": (float64) 16683.82,
@@ -1957,7 +1957,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605605400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16658.16,
       (string) (len=4) "high": (float64) 16695.46,
       (string) (len=3) "low": (float64) 16637.02,
@@ -1969,7 +1969,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605607200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16736.84,
       (string) (len=4) "high": (float64) 16740.43,
       (string) (len=3) "low": (float64) 16650.38,
@@ -1981,7 +1981,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605609000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16783.73,
       (string) (len=4) "high": (float64) 16785,
       (string) (len=3) "low": (float64) 16712.66,
@@ -1993,7 +1993,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605610800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16940.25,
       (string) (len=4) "high": (float64) 16943.99,
       (string) (len=3) "low": (float64) 16750.01,
@@ -2005,7 +2005,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605612600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16999.41,
       (string) (len=4) "high": (float64) 17000,
       (string) (len=3) "low": (float64) 16910.26,
@@ -2017,7 +2017,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605614400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17012.95,
       (string) (len=4) "high": (float64) 17081.38,
       (string) (len=3) "low": (float64) 16941.08,
@@ -2029,7 +2029,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605616200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17094.97,
       (string) (len=4) "high": (float64) 17100,
       (string) (len=3) "low": (float64) 16982,
@@ -2041,7 +2041,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605618000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17031.47,
       (string) (len=4) "high": (float64) 17100,
       (string) (len=3) "low": (float64) 16933.56,
@@ -2053,7 +2053,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605619800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16957.88,
       (string) (len=4) "high": (float64) 17061.92,
       (string) (len=3) "low": (float64) 16945.87,
@@ -2065,7 +2065,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605621600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17059.61,
       (string) (len=4) "high": (float64) 17080,
       (string) (len=3) "low": (float64) 16941.28,
@@ -2077,7 +2077,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605623400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17181.67,
       (string) (len=4) "high": (float64) 17207,
       (string) (len=3) "low": (float64) 17038.43,
@@ -2089,7 +2089,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605625200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17219.57,
       (string) (len=4) "high": (float64) 17247,
       (string) (len=3) "low": (float64) 17150,
@@ -2101,7 +2101,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605627000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17355.87,
       (string) (len=4) "high": (float64) 17398,
       (string) (len=3) "low": (float64) 17212.36,
@@ -2113,7 +2113,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605628800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17400,
       (string) (len=4) "high": (float64) 17400,
       (string) (len=3) "low": (float64) 17295.5,
@@ -2125,7 +2125,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605630600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17668.83,
       (string) (len=4) "high": (float64) 17756.67,
       (string) (len=3) "low": (float64) 17400,
@@ -2137,7 +2137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605632400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17639.5,
       (string) (len=4) "high": (float64) 17750,
       (string) (len=3) "low": (float64) 17435,
@@ -2149,7 +2149,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605634200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17834.89,
       (string) (len=4) "high": (float64) 17880,
       (string) (len=3) "low": (float64) 17642.36,
@@ -2161,7 +2161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605636000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17745.32,
       (string) (len=4) "high": (float64) 17849.31,
       (string) (len=3) "low": (float64) 17616.92,
@@ -2173,7 +2173,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605637800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17650.9,
       (string) (len=4) "high": (float64) 17850,
       (string) (len=3) "low": (float64) 17631.23,
@@ -2185,7 +2185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605639600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17685.76,
       (string) (len=4) "high": (float64) 17722,
       (string) (len=3) "low": (float64) 17509.22,
@@ -2197,7 +2197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605641400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17699.45,
       (string) (len=4) "high": (float64) 17774.12,
       (string) (len=3) "low": (float64) 17621.05,
@@ -2209,7 +2209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605643200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17646,
       (string) (len=4) "high": (float64) 17745,
       (string) (len=3) "low": (float64) 17640.25,
@@ -2221,7 +2221,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605645000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17691.72,
       (string) (len=4) "high": (float64) 17738.62,
       (string) (len=3) "low": (float64) 17641,
@@ -2233,7 +2233,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605646800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17562.76,
       (string) (len=4) "high": (float64) 17720.65,
       (string) (len=3) "low": (float64) 17552.1,
@@ -2245,7 +2245,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605648600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17644.32,
       (string) (len=4) "high": (float64) 17684.55,
       (string) (len=3) "low": (float64) 17550,
@@ -2257,7 +2257,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605650400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17569.14,
       (string) (len=4) "high": (float64) 17648.12,
       (string) (len=3) "low": (float64) 17470.01,
@@ -2269,7 +2269,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605652200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17619.62,
       (string) (len=4) "high": (float64) 17624.25,
       (string) (len=3) "low": (float64) 17538.72,
@@ -2281,7 +2281,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605654000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17667.31,
       (string) (len=4) "high": (float64) 17721.53,
       (string) (len=3) "low": (float64) 17617.85,
@@ -2293,7 +2293,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605655800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17679.36,
       (string) (len=4) "high": (float64) 17722.76,
       (string) (len=3) "low": (float64) 17638.74,
@@ -2305,7 +2305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605657600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17772.62,
       (string) (len=4) "high": (float64) 17845,
       (string) (len=3) "low": (float64) 17650.9,
@@ -2317,7 +2317,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605659400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17718,
       (string) (len=4) "high": (float64) 17796.3,
       (string) (len=3) "low": (float64) 17618.41,
@@ -2329,7 +2329,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605661200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17710.43,
       (string) (len=4) "high": (float64) 17718.65,
       (string) (len=3) "low": (float64) 17631,
@@ -2341,7 +2341,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605663000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17764.05,
       (string) (len=4) "high": (float64) 17765.85,
       (string) (len=3) "low": (float64) 17678.3,
@@ -2353,7 +2353,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605664800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17712.96,
       (string) (len=4) "high": (float64) 17762.44,
       (string) (len=3) "low": (float64) 17682.91,
@@ -2365,7 +2365,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605666600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17702.62,
       (string) (len=4) "high": (float64) 17745.85,
       (string) (len=3) "low": (float64) 17660.54,
@@ -2377,7 +2377,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605668400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17732.3,
       (string) (len=4) "high": (float64) 17734.3,
       (string) (len=3) "low": (float64) 17650,
@@ -2389,7 +2389,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605670200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18059.1,
       (string) (len=4) "high": (float64) 18095,
       (string) (len=3) "low": (float64) 17720.24,
@@ -2401,7 +2401,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605672000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18181.25,
       (string) (len=4) "high": (float64) 18288,
       (string) (len=3) "low": (float64) 17970.14,
@@ -2413,7 +2413,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605673800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18390.49,
       (string) (len=4) "high": (float64) 18488,
       (string) (len=3) "low": (float64) 18162.46,
@@ -2425,7 +2425,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605675600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18267.37,
       (string) (len=4) "high": (float64) 18390.52,
       (string) (len=3) "low": (float64) 18173.01,
@@ -2437,7 +2437,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605677400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17639.68,
       (string) (len=4) "high": (float64) 18286.15,
       (string) (len=3) "low": (float64) 17205.02,
@@ -2449,7 +2449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605679200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17767.11,
       (string) (len=4) "high": (float64) 17894.68,
       (string) (len=3) "low": (float64) 17471.68,
@@ -2461,7 +2461,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605681000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17792.99,
       (string) (len=4) "high": (float64) 17850,
       (string) (len=3) "low": (float64) 17760.1,
@@ -2473,7 +2473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605682800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17778.27,
       (string) (len=4) "high": (float64) 17861.31,
       (string) (len=3) "low": (float64) 17679.12,
@@ -2485,7 +2485,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605684600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18089.38,
       (string) (len=4) "high": (float64) 18110.86,
       (string) (len=3) "low": (float64) 17775,
@@ -2497,7 +2497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605686400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18163.98,
       (string) (len=4) "high": (float64) 18237.86,
       (string) (len=3) "low": (float64) 18055.38,
@@ -2509,7 +2509,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605688200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18227.35,
       (string) (len=4) "high": (float64) 18282.3,
       (string) (len=3) "low": (float64) 18115.32,
@@ -2521,7 +2521,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605690000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17952.5,
       (string) (len=4) "high": (float64) 18242.81,
       (string) (len=3) "low": (float64) 17900.01,
@@ -2533,7 +2533,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605691800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18122.99,
       (string) (len=4) "high": (float64) 18151.26,
       (string) (len=3) "low": (float64) 17902.62,
@@ -2545,7 +2545,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605693600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18152.56,
       (string) (len=4) "high": (float64) 18172.78,
       (string) (len=3) "low": (float64) 17994.56,
@@ -2557,7 +2557,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605695400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18265.85,
       (string) (len=4) "high": (float64) 18267.15,
       (string) (len=3) "low": (float64) 18123.87,
@@ -2569,7 +2569,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605697200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18135.16,
       (string) (len=4) "high": (float64) 18267.83,
       (string) (len=3) "low": (float64) 18100,
@@ -2581,7 +2581,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605699000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18266.09,
       (string) (len=4) "high": (float64) 18269.16,
       (string) (len=3) "low": (float64) 18018.47,
@@ -2593,7 +2593,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605700800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18200,
       (string) (len=4) "high": (float64) 18269.15,
       (string) (len=3) "low": (float64) 18160.82,
@@ -2605,7 +2605,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605702600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18043.18,
       (string) (len=4) "high": (float64) 18220.68,
       (string) (len=3) "low": (float64) 18000,
@@ -2617,7 +2617,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605704400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18001.14,
       (string) (len=4) "high": (float64) 18117.2,
       (string) (len=3) "low": (float64) 17946.8,
@@ -2629,7 +2629,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605706200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17898.7,
       (string) (len=4) "high": (float64) 18100,
       (string) (len=3) "low": (float64) 17811.25,
@@ -2641,7 +2641,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605708000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17881.63,
       (string) (len=4) "high": (float64) 17965.41,
       (string) (len=3) "low": (float64) 17774.7,
@@ -2653,7 +2653,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605709800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17704.83,
       (string) (len=4) "high": (float64) 17896.24,
       (string) (len=3) "low": (float64) 17679,
@@ -2665,7 +2665,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605711600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17581.66,
       (string) (len=4) "high": (float64) 17740.31,
       (string) (len=3) "low": (float64) 17275.04,
@@ -2677,7 +2677,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605713400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17896.84,
       (string) (len=4) "high": (float64) 17930,
       (string) (len=3) "low": (float64) 17556.3,
@@ -2689,7 +2689,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605715200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17909.21,
       (string) (len=4) "high": (float64) 18029.78,
       (string) (len=3) "low": (float64) 17650,
@@ -2701,7 +2701,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605717000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17819.85,
       (string) (len=4) "high": (float64) 17980,
       (string) (len=3) "low": (float64) 17794.01,
@@ -2713,7 +2713,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605718800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17794.85,
       (string) (len=4) "high": (float64) 17896.79,
       (string) (len=3) "low": (float64) 17720.54,
@@ -2725,7 +2725,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605720600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17903.99,
       (string) (len=4) "high": (float64) 17934.76,
       (string) (len=3) "low": (float64) 17783.42,
@@ -2737,7 +2737,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605722400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17871.44,
       (string) (len=4) "high": (float64) 17980,
       (string) (len=3) "low": (float64) 17866.03,
@@ -2749,7 +2749,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605724200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17785.05,
       (string) (len=4) "high": (float64) 17922.88,
       (string) (len=3) "low": (float64) 17760.56,
@@ -2761,7 +2761,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605726000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17666.18,
       (string) (len=4) "high": (float64) 17850,
       (string) (len=3) "low": (float64) 17607.3,
@@ -2773,7 +2773,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605727800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17671.91,
       (string) (len=4) "high": (float64) 17750,
       (string) (len=3) "low": (float64) 17580,
@@ -2785,7 +2785,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605729600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17587.22,
       (string) (len=4) "high": (float64) 17741.13,
       (string) (len=3) "low": (float64) 17552.34,
@@ -2797,7 +2797,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605731400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17655.65,
       (string) (len=4) "high": (float64) 17680,
       (string) (len=3) "low": (float64) 17505.05,
@@ -2809,7 +2809,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605733200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17698.63,
       (string) (len=4) "high": (float64) 17766.6,
       (string) (len=3) "low": (float64) 17636.07,
@@ -2821,7 +2821,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605735000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17785.63,
       (string) (len=4) "high": (float64) 17800,
       (string) (len=3) "low": (float64) 17607.49,
@@ -2833,7 +2833,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605736800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17735.69,
       (string) (len=4) "high": (float64) 17849.99,
       (string) (len=3) "low": (float64) 17725,
@@ -2845,7 +2845,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605738600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17834.51,
       (string) (len=4) "high": (float64) 17881.76,
       (string) (len=3) "low": (float64) 17733.23,
@@ -2857,7 +2857,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605740400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17729,
       (string) (len=4) "high": (float64) 17865.29,
       (string) (len=3) "low": (float64) 17673.45,
@@ -2869,7 +2869,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605742200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17782.91,
       (string) (len=4) "high": (float64) 17872.99,
       (string) (len=3) "low": (float64) 17732.32,
@@ -2881,7 +2881,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605744000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17675.45,
       (string) (len=4) "high": (float64) 17817.15,
       (string) (len=3) "low": (float64) 17626.37,
@@ -2893,7 +2893,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605745800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17774.33,
       (string) (len=4) "high": (float64) 17830.72,
       (string) (len=3) "low": (float64) 17594.07,
@@ -2905,7 +2905,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605747600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17736.69,
       (string) (len=4) "high": (float64) 17779.38,
       (string) (len=3) "low": (float64) 17702.25,
@@ -2917,7 +2917,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605749400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17872.73,
       (string) (len=4) "high": (float64) 17883.51,
       (string) (len=3) "low": (float64) 17735.46,
@@ -2929,7 +2929,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605751200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18052.4,
       (string) (len=4) "high": (float64) 18075.5,
       (string) (len=3) "low": (float64) 17872.01,
@@ -2941,7 +2941,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605753000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17945.69,
       (string) (len=4) "high": (float64) 18053.67,
       (string) (len=3) "low": (float64) 17914.62,
@@ -2953,7 +2953,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605754800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17949.6,
       (string) (len=4) "high": (float64) 18015.41,
       (string) (len=3) "low": (float64) 17917.68,
@@ -2965,7 +2965,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605756600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17935.44,
       (string) (len=4) "high": (float64) 17950,
       (string) (len=3) "low": (float64) 17863.99,
@@ -2977,7 +2977,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605758400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17793.46,
       (string) (len=4) "high": (float64) 17938.81,
       (string) (len=3) "low": (float64) 17761,
@@ -2989,7 +2989,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605760200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17871.04,
       (string) (len=4) "high": (float64) 17884.29,
       (string) (len=3) "low": (float64) 17778.09,
@@ -3001,7 +3001,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605762000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17829.17,
       (string) (len=4) "high": (float64) 17871.03,
       (string) (len=3) "low": (float64) 17735.01,
@@ -3013,7 +3013,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605763800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17912.24,
       (string) (len=4) "high": (float64) 17924.82,
       (string) (len=3) "low": (float64) 17768.93,
@@ -3025,7 +3025,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605765600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17788.94,
       (string) (len=4) "high": (float64) 17922.04,
       (string) (len=3) "low": (float64) 17788.89,
@@ -3037,7 +3037,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605767400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17765.37,
       (string) (len=4) "high": (float64) 17809.06,
       (string) (len=3) "low": (float64) 17718.27,
@@ -3049,7 +3049,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605769200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17749.02,
       (string) (len=4) "high": (float64) 17781.17,
       (string) (len=3) "low": (float64) 17660.74,
@@ -3061,7 +3061,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605771000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17669.7,
       (string) (len=4) "high": (float64) 17768.78,
       (string) (len=3) "low": (float64) 17610.02,
@@ -3073,7 +3073,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605772800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17576.8,
       (string) (len=4) "high": (float64) 17739.9,
       (string) (len=3) "low": (float64) 17522.42,
@@ -3085,7 +3085,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605774600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17544.95,
       (string) (len=4) "high": (float64) 17644.9,
       (string) (len=3) "low": (float64) 17404.63,
@@ -3097,7 +3097,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605776400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17598.16,
       (string) (len=4) "high": (float64) 17643.68,
       (string) (len=3) "low": (float64) 17507.15,
@@ -3109,7 +3109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605778200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17439.8,
       (string) (len=4) "high": (float64) 17623.01,
       (string) (len=3) "low": (float64) 17356,
@@ -3121,7 +3121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605780000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17475.86,
       (string) (len=4) "high": (float64) 17516.35,
       (string) (len=3) "low": (float64) 17376.21,
@@ -3133,7 +3133,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605781800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17624,
       (string) (len=4) "high": (float64) 17656.11,
       (string) (len=3) "low": (float64) 17375.86,
@@ -3145,7 +3145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605783600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17617.31,
       (string) (len=4) "high": (float64) 17772.01,
       (string) (len=3) "low": (float64) 17596.56,
@@ -3157,7 +3157,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605785400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17770.49,
       (string) (len=4) "high": (float64) 17775,
       (string) (len=3) "low": (float64) 17612.18,
@@ -3169,7 +3169,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605787200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17709.38,
       (string) (len=4) "high": (float64) 17817.84,
       (string) (len=3) "low": (float64) 17663.14,
@@ -3181,7 +3181,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605789000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17720.42,
       (string) (len=4) "high": (float64) 17803.32,
       (string) (len=3) "low": (float64) 17700.01,
@@ -3193,7 +3193,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605790800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17968.27,
       (string) (len=4) "high": (float64) 17978.71,
       (string) (len=3) "low": (float64) 17717.54,
@@ -3205,7 +3205,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605792600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18010.66,
       (string) (len=4) "high": (float64) 18025.63,
       (string) (len=3) "low": (float64) 17901.18,
@@ -3217,7 +3217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605794400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17925.31,
       (string) (len=4) "high": (float64) 18047.99,
       (string) (len=3) "low": (float64) 17870.61,
@@ -3229,7 +3229,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605796200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18133.01,
       (string) (len=4) "high": (float64) 18158.93,
       (string) (len=3) "low": (float64) 17857.38,
@@ -3241,7 +3241,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605798000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18111.51,
       (string) (len=4) "high": (float64) 18193.29,
       (string) (len=3) "low": (float64) 18061.97,
@@ -3253,7 +3253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605799800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18064.84,
       (string) (len=4) "high": (float64) 18139.07,
       (string) (len=3) "low": (float64) 18033,
@@ -3265,7 +3265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605801600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17978.47,
       (string) (len=4) "high": (float64) 18135,
       (string) (len=3) "low": (float64) 17927.44,
@@ -3277,7 +3277,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605803400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18020.57,
       (string) (len=4) "high": (float64) 18063.6,
       (string) (len=3) "low": (float64) 17960.05,
@@ -3289,7 +3289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605805200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17965.67,
       (string) (len=4) "high": (float64) 18054.88,
       (string) (len=3) "low": (float64) 17902.06,
@@ -3301,7 +3301,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605807000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17982.2,
       (string) (len=4) "high": (float64) 18028.52,
       (string) (len=3) "low": (float64) 17924.64,
@@ -3313,7 +3313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605808800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18008.41,
       (string) (len=4) "high": (float64) 18046.92,
       (string) (len=3) "low": (float64) 17975.62,
@@ -3325,7 +3325,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605810600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17953.3,
       (string) (len=4) "high": (float64) 18039.17,
       (string) (len=3) "low": (float64) 17925.38,
@@ -3337,7 +3337,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605812400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17924.32,
       (string) (len=4) "high": (float64) 17979.73,
       (string) (len=3) "low": (float64) 17890,
@@ -3349,7 +3349,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605814200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17979.02,
       (string) (len=4) "high": (float64) 17990,
       (string) (len=3) "low": (float64) 17909.38,
@@ -3361,7 +3361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605816000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18005.57,
       (string) (len=4) "high": (float64) 18018.41,
       (string) (len=3) "low": (float64) 17925.17,
@@ -3373,7 +3373,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605817800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18046.37,
       (string) (len=4) "high": (float64) 18057.29,
       (string) (len=3) "low": (float64) 17979.77,
@@ -3385,7 +3385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605819600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18056.09,
       (string) (len=4) "high": (float64) 18110.05,
       (string) (len=3) "low": (float64) 17993,
@@ -3397,7 +3397,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605821400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17950.99,
       (string) (len=4) "high": (float64) 18062.28,
       (string) (len=3) "low": (float64) 17900,
@@ -3409,7 +3409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605823200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17910.45,
       (string) (len=4) "high": (float64) 17975,
       (string) (len=3) "low": (float64) 17905,
@@ -3421,7 +3421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605825000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17881,
       (string) (len=4) "high": (float64) 17971.22,
       (string) (len=3) "low": (float64) 17881,
@@ -3433,7 +3433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605826800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17780.13,
       (string) (len=4) "high": (float64) 17909.85,
       (string) (len=3) "low": (float64) 17719.24,
@@ -3445,7 +3445,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605828600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17821.58,
       (string) (len=4) "high": (float64) 17860.63,
       (string) (len=3) "low": (float64) 17770.77,
@@ -3457,7 +3457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605830400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17885.77,
       (string) (len=4) "high": (float64) 17954.96,
       (string) (len=3) "low": (float64) 17802.45,
@@ -3469,7 +3469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605832200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17794.33,
       (string) (len=4) "high": (float64) 17889.94,
       (string) (len=3) "low": (float64) 17775,
@@ -3481,7 +3481,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605834000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17894.91,
       (string) (len=4) "high": (float64) 17898.71,
       (string) (len=3) "low": (float64) 17764.76,
@@ -3493,7 +3493,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605835800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17976.51,
       (string) (len=4) "high": (float64) 17984.85,
       (string) (len=3) "low": (float64) 17875.83,
@@ -3505,7 +3505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605837600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18044.81,
       (string) (len=4) "high": (float64) 18047.88,
       (string) (len=3) "low": (float64) 17931.14,
@@ -3517,7 +3517,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605839400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17976.35,
       (string) (len=4) "high": (float64) 18058.24,
       (string) (len=3) "low": (float64) 17967.24,
@@ -3529,7 +3529,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605841200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18006.92,
       (string) (len=4) "high": (float64) 18036.29,
       (string) (len=3) "low": (float64) 17954,
@@ -3541,7 +3541,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605843000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17961.26,
       (string) (len=4) "high": (float64) 18025,
       (string) (len=3) "low": (float64) 17950.13,
@@ -3553,7 +3553,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605844800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18090.82,
       (string) (len=4) "high": (float64) 18099,
       (string) (len=3) "low": (float64) 17943.52,
@@ -3565,7 +3565,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605846600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18202.06,
       (string) (len=4) "high": (float64) 18239,
       (string) (len=3) "low": (float64) 18085.18,
@@ -3577,7 +3577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605848400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18099.03,
       (string) (len=4) "high": (float64) 18228.98,
       (string) (len=3) "low": (float64) 18059.12,
@@ -3589,7 +3589,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605850200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18142,
       (string) (len=4) "high": (float64) 18186.64,
       (string) (len=3) "low": (float64) 18099,
@@ -3601,7 +3601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605852000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18097.65,
       (string) (len=4) "high": (float64) 18190.9,
       (string) (len=3) "low": (float64) 18080.24,
@@ -3613,7 +3613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605853800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18174.46,
       (string) (len=4) "high": (float64) 18177.97,
       (string) (len=3) "low": (float64) 18087.15,
@@ -3625,7 +3625,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605855600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18198.76,
       (string) (len=4) "high": (float64) 18421.63,
       (string) (len=3) "low": (float64) 18093.8,
@@ -3637,7 +3637,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605857400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18222.21,
       (string) (len=4) "high": (float64) 18241.77,
       (string) (len=3) "low": (float64) 18113.23,
@@ -3649,7 +3649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605859200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18286.74,
       (string) (len=4) "high": (float64) 18340.99,
       (string) (len=3) "low": (float64) 18161.69,
@@ -3661,7 +3661,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605861000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18320.01,
       (string) (len=4) "high": (float64) 18342.73,
       (string) (len=3) "low": (float64) 18255.01,
@@ -3673,7 +3673,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605862800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18286.22,
       (string) (len=4) "high": (float64) 18389.03,
       (string) (len=3) "low": (float64) 18222.44,
@@ -3685,7 +3685,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605864600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18200.79,
       (string) (len=4) "high": (float64) 18286.7,
       (string) (len=3) "low": (float64) 18117.48,
@@ -3697,7 +3697,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605866400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18244.66,
       (string) (len=4) "high": (float64) 18249.42,
       (string) (len=3) "low": (float64) 18155.26,
@@ -3709,7 +3709,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605868200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18310.36,
       (string) (len=4) "high": (float64) 18349,
       (string) (len=3) "low": (float64) 18199.3,
@@ -3721,7 +3721,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605870000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18320.35,
       (string) (len=4) "high": (float64) 18370.35,
       (string) (len=3) "low": (float64) 18279.16,
@@ -3733,7 +3733,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605871800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18287.73,
       (string) (len=4) "high": (float64) 18347.22,
       (string) (len=3) "low": (float64) 18276.03,
@@ -3745,7 +3745,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605873600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18272.94,
       (string) (len=4) "high": (float64) 18313.68,
       (string) (len=3) "low": (float64) 18209.32,
@@ -3757,7 +3757,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605875400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18245.93,
       (string) (len=4) "high": (float64) 18309.95,
       (string) (len=3) "low": (float64) 18170.72,
@@ -3769,7 +3769,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605877200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18180.01,
       (string) (len=4) "high": (float64) 18264.95,
       (string) (len=3) "low": (float64) 18175.8,
@@ -3781,7 +3781,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605879000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18259.54,
       (string) (len=4) "high": (float64) 18306.23,
       (string) (len=3) "low": (float64) 18161.23,
@@ -3793,7 +3793,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605880800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18370.79,
       (string) (len=4) "high": (float64) 18398.94,
       (string) (len=3) "low": (float64) 18257.11,
@@ -3805,7 +3805,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605882600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18656.45,
       (string) (len=4) "high": (float64) 18656.45,
       (string) (len=3) "low": (float64) 18357.13,
@@ -3817,7 +3817,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605884400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18698.01,
       (string) (len=4) "high": (float64) 18756,
       (string) (len=3) "low": (float64) 18525.77,
@@ -3829,7 +3829,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605886200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18692.32,
       (string) (len=4) "high": (float64) 18762.32,
       (string) (len=3) "low": (float64) 18650,
@@ -3841,7 +3841,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605888000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18793.62,
       (string) (len=4) "high": (float64) 18830.3,
       (string) (len=3) "low": (float64) 18650.02,
@@ -3853,7 +3853,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605889800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18707.07,
       (string) (len=4) "high": (float64) 18808.48,
       (string) (len=3) "low": (float64) 18652.22,
@@ -3865,7 +3865,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605891600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18681.51,
       (string) (len=4) "high": (float64) 18712.43,
       (string) (len=3) "low": (float64) 18557.79,
@@ -3877,7 +3877,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605893400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18711.49,
       (string) (len=4) "high": (float64) 18724.58,
       (string) (len=3) "low": (float64) 18669.04,
@@ -3889,7 +3889,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605895200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18568.72,
       (string) (len=4) "high": (float64) 18713.8,
       (string) (len=3) "low": (float64) 18520,
@@ -3901,7 +3901,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605897000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18593.08,
       (string) (len=4) "high": (float64) 18613.03,
       (string) (len=3) "low": (float64) 18400.01,
@@ -3913,7 +3913,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605898800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18653.16,
       (string) (len=4) "high": (float64) 18657.27,
       (string) (len=3) "low": (float64) 18544.6,
@@ -3925,7 +3925,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605900600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18640,
       (string) (len=4) "high": (float64) 18684.24,
       (string) (len=3) "low": (float64) 18626.82,
@@ -3937,7 +3937,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605902400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18601.71,
       (string) (len=4) "high": (float64) 18702,
       (string) (len=3) "low": (float64) 18601.24,
@@ -3949,7 +3949,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605904200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18650.58,
       (string) (len=4) "high": (float64) 18709.99,
       (string) (len=3) "low": (float64) 18587.01,
@@ -3961,7 +3961,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605906000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18579.19,
       (string) (len=4) "high": (float64) 18671.79,
       (string) (len=3) "low": (float64) 18540,
@@ -3973,7 +3973,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605907800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18599.58,
       (string) (len=4) "high": (float64) 18656.02,
       (string) (len=3) "low": (float64) 18564.7,
@@ -3985,7 +3985,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605909600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18556.04,
       (string) (len=4) "high": (float64) 18624.78,
       (string) (len=3) "low": (float64) 18501.95,
@@ -3997,7 +3997,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605911400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18640.35,
       (string) (len=4) "high": (float64) 18648.84,
       (string) (len=3) "low": (float64) 18510.77,
@@ -4009,7 +4009,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605913200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18663.92,
       (string) (len=4) "high": (float64) 18767,
       (string) (len=3) "low": (float64) 18558.42,
@@ -4021,7 +4021,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605915000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18675.25,
       (string) (len=4) "high": (float64) 18695.18,
       (string) (len=3) "low": (float64) 18639.1,
@@ -4033,7 +4033,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605916800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18767.11,
       (string) (len=4) "high": (float64) 18771.8,
       (string) (len=3) "low": (float64) 18640,
@@ -4045,7 +4045,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605918600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18886.39,
       (string) (len=4) "high": (float64) 18887.72,
       (string) (len=3) "low": (float64) 18745.2,
@@ -4057,7 +4057,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605920400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18910.65,
       (string) (len=4) "high": (float64) 18925,
       (string) (len=3) "low": (float64) 18787.69,
@@ -4069,7 +4069,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605922200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18850,
       (string) (len=4) "high": (float64) 18918.03,
       (string) (len=3) "low": (float64) 18839.67,
@@ -4081,7 +4081,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605924000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18969.9,
       (string) (len=4) "high": (float64) 18980,
       (string) (len=3) "low": (float64) 18848,
@@ -4093,7 +4093,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605925800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18762.54,
       (string) (len=4) "high": (float64) 18969.91,
       (string) (len=3) "low": (float64) 18677,
@@ -4105,7 +4105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605927600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18806.83,
       (string) (len=4) "high": (float64) 18835.01,
       (string) (len=3) "low": (float64) 18672,
@@ -4117,7 +4117,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605929400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18676.49,
       (string) (len=4) "high": (float64) 18841.31,
       (string) (len=3) "low": (float64) 18650.01,
@@ -4129,7 +4129,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605931200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18598.76,
       (string) (len=4) "high": (float64) 18683.12,
       (string) (len=3) "low": (float64) 18460.31,
@@ -4141,7 +4141,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605933000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18599.89,
       (string) (len=4) "high": (float64) 18645.75,
       (string) (len=3) "low": (float64) 18541.58,
@@ -4153,7 +4153,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605934800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18647.18,
       (string) (len=4) "high": (float64) 18681.27,
       (string) (len=3) "low": (float64) 18571.26,
@@ -4165,7 +4165,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605936600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18672.97,
       (string) (len=4) "high": (float64) 18692.84,
       (string) (len=3) "low": (float64) 18577.89,
@@ -4177,7 +4177,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605938400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18713.61,
       (string) (len=4) "high": (float64) 18748.98,
       (string) (len=3) "low": (float64) 18643.97,
@@ -4189,7 +4189,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605940200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18653.66,
       (string) (len=4) "high": (float64) 18719.57,
       (string) (len=3) "low": (float64) 18627.44,
@@ -4201,7 +4201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605942000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18744.42,
       (string) (len=4) "high": (float64) 18750,
       (string) (len=3) "low": (float64) 18630,
@@ -4213,7 +4213,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605943800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18682.64,
       (string) (len=4) "high": (float64) 18754.63,
       (string) (len=3) "low": (float64) 18678.43,
@@ -4225,7 +4225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605945600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18782.69,
       (string) (len=4) "high": (float64) 18782.74,
       (string) (len=3) "low": (float64) 18680.79,
@@ -4237,7 +4237,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605947400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18807.99,
       (string) (len=4) "high": (float64) 18808.02,
       (string) (len=3) "low": (float64) 18721.27,
@@ -4249,7 +4249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605949200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18702.87,
       (string) (len=4) "high": (float64) 18808,
       (string) (len=3) "low": (float64) 18672.28,
@@ -4261,7 +4261,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605951000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18633.42,
       (string) (len=4) "high": (float64) 18702.37,
       (string) (len=3) "low": (float64) 18570.11,
@@ -4273,7 +4273,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605952800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18702.2,
       (string) (len=4) "high": (float64) 18728.85,
       (string) (len=3) "low": (float64) 18600,
@@ -4285,7 +4285,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605954600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18611.57,
       (string) (len=4) "high": (float64) 18712.33,
       (string) (len=3) "low": (float64) 18587.92,
@@ -4297,7 +4297,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605956400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18565.69,
       (string) (len=4) "high": (float64) 18671.52,
       (string) (len=3) "low": (float64) 18535.05,
@@ -4309,7 +4309,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605958200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18550.01,
       (string) (len=4) "high": (float64) 18604.95,
       (string) (len=3) "low": (float64) 18507.66,
@@ -4321,7 +4321,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605960000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18694.09,
       (string) (len=4) "high": (float64) 18720,
       (string) (len=3) "low": (float64) 18350,
@@ -4333,7 +4333,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605961800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18656.82,
       (string) (len=4) "high": (float64) 18700,
       (string) (len=3) "low": (float64) 18636.44,
@@ -4345,7 +4345,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605963600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18733.39,
       (string) (len=4) "high": (float64) 18735.38,
       (string) (len=3) "low": (float64) 18655.51,
@@ -4357,7 +4357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605965400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18812.52,
       (string) (len=4) "high": (float64) 18849,
       (string) (len=3) "low": (float64) 18717.88,
@@ -4369,7 +4369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605967200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18705.04,
       (string) (len=4) "high": (float64) 18822.72,
       (string) (len=3) "low": (float64) 18664.34,
@@ -4381,7 +4381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605969000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18756.04,
       (string) (len=4) "high": (float64) 18798.94,
       (string) (len=3) "low": (float64) 18662.76,
@@ -4393,7 +4393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605970800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18812.72,
       (string) (len=4) "high": (float64) 18845,
       (string) (len=3) "low": (float64) 18659.74,
@@ -4405,7 +4405,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605972600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18818.15,
       (string) (len=4) "high": (float64) 18832.98,
       (string) (len=3) "low": (float64) 18752.13,
@@ -4417,7 +4417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605974400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18869.26,
       (string) (len=4) "high": (float64) 18924.47,
       (string) (len=3) "low": (float64) 18779.14,
@@ -4429,7 +4429,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605976200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18768.77,
       (string) (len=4) "high": (float64) 18933.3,
       (string) (len=3) "low": (float64) 18690.25,
@@ -4441,7 +4441,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605978000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18740.05,
       (string) (len=4) "high": (float64) 18804.35,
       (string) (len=3) "low": (float64) 18680,
@@ -4453,7 +4453,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605979800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18772.96,
       (string) (len=4) "high": (float64) 18791.21,
       (string) (len=3) "low": (float64) 18715.56,
@@ -4465,7 +4465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605981600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18759.99,
       (string) (len=4) "high": (float64) 18811.71,
       (string) (len=3) "low": (float64) 18737.33,
@@ -4477,7 +4477,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605983400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18762.62,
       (string) (len=4) "high": (float64) 18818.34,
       (string) (len=3) "low": (float64) 18743.29,
@@ -4489,7 +4489,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605985200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18675.77,
       (string) (len=4) "high": (float64) 18795.02,
       (string) (len=3) "low": (float64) 18675,
@@ -4501,7 +4501,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605987000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18697.95,
       (string) (len=4) "high": (float64) 18727.77,
       (string) (len=3) "low": (float64) 18600,
@@ -4513,7 +4513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605988800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18661.67,
       (string) (len=4) "high": (float64) 18698.16,
       (string) (len=3) "low": (float64) 18605.22,
@@ -4525,7 +4525,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605990600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18669.35,
       (string) (len=4) "high": (float64) 18694.2,
       (string) (len=3) "low": (float64) 18635.7,
@@ -4537,7 +4537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605992400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18627.96,
       (string) (len=4) "high": (float64) 18674.58,
       (string) (len=3) "low": (float64) 18601.72,
@@ -4549,7 +4549,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605994200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18670.94,
       (string) (len=4) "high": (float64) 18713.54,
       (string) (len=3) "low": (float64) 18626.45,
@@ -4561,7 +4561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605996000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18599.56,
       (string) (len=4) "high": (float64) 18674.06,
       (string) (len=3) "low": (float64) 18541.47,
@@ -4573,7 +4573,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605997800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18648.07,
       (string) (len=4) "high": (float64) 18660.6,
       (string) (len=3) "low": (float64) 18587.28,
@@ -4585,7 +4585,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605999600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18693.06,
       (string) (len=4) "high": (float64) 18694.4,
       (string) (len=3) "low": (float64) 18621.96,
@@ -4597,7 +4597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606001400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18721.21,
       (string) (len=4) "high": (float64) 18767.03,
       (string) (len=3) "low": (float64) 18676.16,
@@ -4609,7 +4609,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606003200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18700.03,
       (string) (len=4) "high": (float64) 18773.56,
       (string) (len=3) "low": (float64) 18679.6,
@@ -4621,7 +4621,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606005000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18556.81,
       (string) (len=4) "high": (float64) 18721.58,
       (string) (len=3) "low": (float64) 18522.22,
@@ -4633,7 +4633,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606006800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18535.76,
       (string) (len=4) "high": (float64) 18622.16,
       (string) (len=3) "low": (float64) 18489.23,
@@ -4645,7 +4645,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606008600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18473.48,
       (string) (len=4) "high": (float64) 18536.7,
       (string) (len=3) "low": (float64) 18355.45,
@@ -4657,7 +4657,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606010400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18503.93,
       (string) (len=4) "high": (float64) 18529.66,
       (string) (len=3) "low": (float64) 18443.58,
@@ -4669,7 +4669,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606012200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18601.52,
       (string) (len=4) "high": (float64) 18622.38,
       (string) (len=3) "low": (float64) 18489.5,
@@ -4681,7 +4681,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606014000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18498.98,
       (string) (len=4) "high": (float64) 18608.71,
       (string) (len=3) "low": (float64) 18498.96,
@@ -4693,7 +4693,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606015800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18574.3,
       (string) (len=4) "high": (float64) 18589.29,
       (string) (len=3) "low": (float64) 18498.97,
@@ -4705,7 +4705,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606017600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18529.2,
       (string) (len=4) "high": (float64) 18592.08,
       (string) (len=3) "low": (float64) 18450,
@@ -4717,7 +4717,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606019400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18608.67,
       (string) (len=4) "high": (float64) 18617.96,
       (string) (len=3) "low": (float64) 18529.4,
@@ -4729,7 +4729,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606021200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18564.39,
       (string) (len=4) "high": (float64) 18608.67,
       (string) (len=3) "low": (float64) 18546.68,
@@ -4741,7 +4741,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606023000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18526.4,
       (string) (len=4) "high": (float64) 18562.59,
       (string) (len=3) "low": (float64) 18500,
@@ -4753,7 +4753,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606024800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18464.02,
       (string) (len=4) "high": (float64) 18598.94,
       (string) (len=3) "low": (float64) 18410.41,
@@ -4765,7 +4765,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606026600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18490.83,
       (string) (len=4) "high": (float64) 18523.37,
       (string) (len=3) "low": (float64) 18423.76,
@@ -4777,7 +4777,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606028400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18359.01,
       (string) (len=4) "high": (float64) 18490.83,
       (string) (len=3) "low": (float64) 18359,
@@ -4789,7 +4789,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606030200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18517.26,
       (string) (len=4) "high": (float64) 18527.51,
       (string) (len=3) "low": (float64) 18288.9,
@@ -4801,7 +4801,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606032000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18381.56,
       (string) (len=4) "high": (float64) 18516.67,
       (string) (len=3) "low": (float64) 18345.56,
@@ -4813,7 +4813,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606033800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18219.49,
       (string) (len=4) "high": (float64) 18410.85,
       (string) (len=3) "low": (float64) 18188,
@@ -4825,7 +4825,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606035600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18269.71,
       (string) (len=4) "high": (float64) 18358.77,
       (string) (len=3) "low": (float64) 18159,
@@ -4837,7 +4837,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606037400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18379.44,
       (string) (len=4) "high": (float64) 18428.14,
       (string) (len=3) "low": (float64) 18263.36,
@@ -4849,7 +4849,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606039200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18261.28,
       (string) (len=4) "high": (float64) 18374.75,
       (string) (len=3) "low": (float64) 18252.67,
@@ -4861,7 +4861,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606041000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18177.86,
       (string) (len=4) "high": (float64) 18258.68,
       (string) (len=3) "low": (float64) 18056,
@@ -4873,7 +4873,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606042800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17969.61,
       (string) (len=4) "high": (float64) 18211.02,
       (string) (len=3) "low": (float64) 17960,
@@ -4885,7 +4885,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606044600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17891.13,
       (string) (len=4) "high": (float64) 18014.59,
       (string) (len=3) "low": (float64) 17610.77,
@@ -4897,7 +4897,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606046400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18067.87,
       (string) (len=4) "high": (float64) 18130.22,
       (string) (len=3) "low": (float64) 17825.04,
@@ -4909,7 +4909,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606048200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18122.58,
       (string) (len=4) "high": (float64) 18161.51,
       (string) (len=3) "low": (float64) 18010.41,
@@ -4921,7 +4921,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606050000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18244.02,
       (string) (len=4) "high": (float64) 18246.26,
       (string) (len=3) "low": (float64) 18067,
@@ -4933,7 +4933,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606051800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18213.22,
       (string) (len=4) "high": (float64) 18252.37,
       (string) (len=3) "low": (float64) 18178.72,
@@ -4945,7 +4945,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606053600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18255.33,
       (string) (len=4) "high": (float64) 18301.92,
       (string) (len=3) "low": (float64) 18159.18,
@@ -4957,7 +4957,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606055400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18195.03,
       (string) (len=4) "high": (float64) 18300,
       (string) (len=3) "low": (float64) 18191.73,
@@ -4969,7 +4969,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606057200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18240.64,
       (string) (len=4) "high": (float64) 18275.79,
       (string) (len=3) "low": (float64) 18190.66,
@@ -4981,7 +4981,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606059000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18312.17,
       (string) (len=4) "high": (float64) 18345.18,
       (string) (len=3) "low": (float64) 18226.21,
@@ -4993,7 +4993,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606060800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18453.41,
       (string) (len=4) "high": (float64) 18466,
       (string) (len=3) "low": (float64) 18272.27,
@@ -5005,7 +5005,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606062600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18566.41,
       (string) (len=4) "high": (float64) 18600,
       (string) (len=3) "low": (float64) 18450,
@@ -5017,7 +5017,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606064400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18556.68,
       (string) (len=4) "high": (float64) 18595.2,
       (string) (len=3) "low": (float64) 18493.36,
@@ -5029,7 +5029,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606066200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18494.57,
       (string) (len=4) "high": (float64) 18557.61,
       (string) (len=3) "low": (float64) 18468.97,
@@ -5041,7 +5041,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606068000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18548.24,
       (string) (len=4) "high": (float64) 18641.01,
       (string) (len=3) "low": (float64) 18486.84,
@@ -5053,7 +5053,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606069800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18522.62,
       (string) (len=4) "high": (float64) 18609.14,
       (string) (len=3) "low": (float64) 18507.95,
@@ -5065,7 +5065,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606071600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18522.91,
       (string) (len=4) "high": (float64) 18589.71,
       (string) (len=3) "low": (float64) 18506.11,
@@ -5077,7 +5077,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606073400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18591.38,
       (string) (len=4) "high": (float64) 18615,
       (string) (len=3) "low": (float64) 18522.71,
@@ -5089,7 +5089,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606075200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18637.74,
       (string) (len=4) "high": (float64) 18700,
       (string) (len=3) "low": (float64) 18591.38,
@@ -5101,7 +5101,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606077000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18576.61,
       (string) (len=4) "high": (float64) 18648.69,
       (string) (len=3) "low": (float64) 18528.55,
@@ -5113,7 +5113,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606078800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18626.64,
       (string) (len=4) "high": (float64) 18631,
       (string) (len=3) "low": (float64) 18515.01,
@@ -5125,7 +5125,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606080600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18600.6,
       (string) (len=4) "high": (float64) 18644.05,
       (string) (len=3) "low": (float64) 18589.81,
@@ -5137,7 +5137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606082400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18653.26,
       (string) (len=4) "high": (float64) 18666.66,
       (string) (len=3) "low": (float64) 18550,
@@ -5149,7 +5149,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606084200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18643.16,
       (string) (len=4) "high": (float64) 18680.85,
       (string) (len=3) "low": (float64) 18605.35,
@@ -5161,7 +5161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606086000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18509.64,
       (string) (len=4) "high": (float64) 18650,
       (string) (len=3) "low": (float64) 18412.24,
@@ -5173,7 +5173,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606087800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18437.66,
       (string) (len=4) "high": (float64) 18558.37,
       (string) (len=3) "low": (float64) 18403.75,
@@ -5185,7 +5185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606089600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18271.42,
       (string) (len=4) "high": (float64) 18529,
       (string) (len=3) "low": (float64) 18235.4,
@@ -5197,7 +5197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606091400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18140,
       (string) (len=4) "high": (float64) 18343.93,
       (string) (len=3) "low": (float64) 18103.83,
@@ -5209,7 +5209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606093200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18110.38,
       (string) (len=4) "high": (float64) 18281.31,
       (string) (len=3) "low": (float64) 18001,
@@ -5221,7 +5221,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606095000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18230,
       (string) (len=4) "high": (float64) 18275,
       (string) (len=3) "low": (float64) 18069.8,
@@ -5233,7 +5233,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606096800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18258.29,
       (string) (len=4) "high": (float64) 18360.86,
       (string) (len=3) "low": (float64) 18210,
@@ -5245,7 +5245,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606098600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18230.78,
       (string) (len=4) "high": (float64) 18318.73,
       (string) (len=3) "low": (float64) 18207.58,
@@ -5257,7 +5257,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606100400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18402.5,
       (string) (len=4) "high": (float64) 18409.2,
       (string) (len=3) "low": (float64) 18196.2,
@@ -5269,7 +5269,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606102200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18378.53,
       (string) (len=4) "high": (float64) 18459.57,
       (string) (len=3) "low": (float64) 18343.52,
@@ -5281,7 +5281,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606104000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18479.32,
       (string) (len=4) "high": (float64) 18534.8,
       (string) (len=3) "low": (float64) 18350,
@@ -5293,7 +5293,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606105800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18480,
       (string) (len=4) "high": (float64) 18533.38,
       (string) (len=3) "low": (float64) 18449.83,
@@ -5305,7 +5305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606107600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18511.49,
       (string) (len=4) "high": (float64) 18524.11,
       (string) (len=3) "low": (float64) 18404.25,
@@ -5317,7 +5317,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606109400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18462.33,
       (string) (len=4) "high": (float64) 18522.52,
       (string) (len=3) "low": (float64) 18456.44,
@@ -5329,7 +5329,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606111200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18343.13,
       (string) (len=4) "high": (float64) 18471.3,
       (string) (len=3) "low": (float64) 18325.01,
@@ -5341,7 +5341,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606113000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18543.84,
       (string) (len=4) "high": (float64) 18544.26,
       (string) (len=3) "low": (float64) 18338.2,
@@ -5353,7 +5353,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606114800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18490.6,
       (string) (len=4) "high": (float64) 18577.46,
       (string) (len=3) "low": (float64) 18443.64,
@@ -5365,7 +5365,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606116600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18468.78,
       (string) (len=4) "high": (float64) 18517.17,
       (string) (len=3) "low": (float64) 18442.05,
@@ -5377,7 +5377,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606118400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18639.99,
       (string) (len=4) "high": (float64) 18649,
       (string) (len=3) "low": (float64) 18469.38,
@@ -5389,7 +5389,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606120200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18588.09,
       (string) (len=4) "high": (float64) 18671.45,
       (string) (len=3) "low": (float64) 18553.6,
@@ -5401,7 +5401,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606122000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18580.05,
       (string) (len=4) "high": (float64) 18634.74,
       (string) (len=3) "low": (float64) 18550,
@@ -5413,7 +5413,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606123800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18665.14,
       (string) (len=4) "high": (float64) 18676.81,
       (string) (len=3) "low": (float64) 18563.84,
@@ -5425,7 +5425,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606125600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18752.97,
       (string) (len=4) "high": (float64) 18755,
       (string) (len=3) "low": (float64) 18653.75,
@@ -5437,7 +5437,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606127400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18767.21,
       (string) (len=4) "high": (float64) 18777.77,
       (string) (len=3) "low": (float64) 18706.94,
@@ -5449,7 +5449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606129200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18633.55,
       (string) (len=4) "high": (float64) 18769.85,
       (string) (len=3) "low": (float64) 18582.38,
@@ -5461,7 +5461,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606131000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18585.01,
       (string) (len=4) "high": (float64) 18688.08,
       (string) (len=3) "low": (float64) 18583.18,
@@ -5473,7 +5473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606132800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18557.96,
       (string) (len=4) "high": (float64) 18642.9,
       (string) (len=3) "low": (float64) 18500,
@@ -5485,7 +5485,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606134600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18637.96,
       (string) (len=4) "high": (float64) 18658.87,
       (string) (len=3) "low": (float64) 18557.95,
@@ -5497,7 +5497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606136400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18422.43,
       (string) (len=4) "high": (float64) 18683.14,
       (string) (len=3) "low": (float64) 18355.4,
@@ -5509,7 +5509,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606138200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18622.69,
       (string) (len=4) "high": (float64) 18624.61,
       (string) (len=3) "low": (float64) 18400,
@@ -5521,7 +5521,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606140000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18581.42,
       (string) (len=4) "high": (float64) 18719.99,
       (string) (len=3) "low": (float64) 18550,
@@ -5533,7 +5533,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606141800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18559.08,
       (string) (len=4) "high": (float64) 18669.21,
       (string) (len=3) "low": (float64) 18521.09,
@@ -5545,7 +5545,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606143600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18385.87,
       (string) (len=4) "high": (float64) 18578.94,
       (string) (len=3) "low": (float64) 18333.33,
@@ -5557,7 +5557,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606145400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18281.63,
       (string) (len=4) "high": (float64) 18425.83,
       (string) (len=3) "low": (float64) 18249.1,
@@ -5569,7 +5569,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606147200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18350.21,
       (string) (len=4) "high": (float64) 18392.19,
       (string) (len=3) "low": (float64) 18250,
@@ -5581,7 +5581,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606149000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18398.05,
       (string) (len=4) "high": (float64) 18425,
       (string) (len=3) "low": (float64) 18158.78,
@@ -5593,7 +5593,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606150800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18435.31,
       (string) (len=4) "high": (float64) 18439.73,
       (string) (len=3) "low": (float64) 18356.08,
@@ -5605,7 +5605,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606152600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18358.71,
       (string) (len=4) "high": (float64) 18482.35,
       (string) (len=3) "low": (float64) 18334.65,
@@ -5617,7 +5617,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606154400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18340.96,
       (string) (len=4) "high": (float64) 18377.93,
       (string) (len=3) "low": (float64) 18296.51,
@@ -5629,7 +5629,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606156200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18357.92,
       (string) (len=4) "high": (float64) 18439.66,
       (string) (len=3) "low": (float64) 18330.01,
@@ -5641,7 +5641,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606158000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18387.13,
       (string) (len=4) "high": (float64) 18397.83,
       (string) (len=3) "low": (float64) 18315.23,
@@ -5653,7 +5653,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606159800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18459.89,
       (string) (len=4) "high": (float64) 18479.59,
       (string) (len=3) "low": (float64) 18383.84,
@@ -5665,7 +5665,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606161600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18408.35,
       (string) (len=4) "high": (float64) 18499.94,
       (string) (len=3) "low": (float64) 18400,
@@ -5677,7 +5677,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606163400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18397.54,
       (string) (len=4) "high": (float64) 18421.91,
       (string) (len=3) "low": (float64) 18367.22,
@@ -5689,7 +5689,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606165200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18412.85,
       (string) (len=4) "high": (float64) 18434.69,
       (string) (len=3) "low": (float64) 18344.63,
@@ -5701,7 +5701,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606167000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18422.02,
       (string) (len=4) "high": (float64) 18473.09,
       (string) (len=3) "low": (float64) 18402.88,
@@ -5713,7 +5713,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606168800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18397.91,
       (string) (len=4) "high": (float64) 18443.18,
       (string) (len=3) "low": (float64) 18363.61,
@@ -5725,7 +5725,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606170600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18435.56,
       (string) (len=4) "high": (float64) 18489.56,
       (string) (len=3) "low": (float64) 18391.74,
@@ -5737,7 +5737,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606172400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18412.51,
       (string) (len=4) "high": (float64) 18457.39,
       (string) (len=3) "low": (float64) 18294.65,
@@ -5749,7 +5749,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606174200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18384.82,
       (string) (len=4) "high": (float64) 18418.03,
       (string) (len=3) "low": (float64) 18313.22,
@@ -5761,7 +5761,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606176000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18238.58,
       (string) (len=4) "high": (float64) 18391.21,
       (string) (len=3) "low": (float64) 18231.2,
@@ -5773,7 +5773,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606177800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18375.7,
       (string) (len=4) "high": (float64) 18380.32,
       (string) (len=3) "low": (float64) 18222,
@@ -5785,7 +5785,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606179600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18533.13,
       (string) (len=4) "high": (float64) 18550,
       (string) (len=3) "low": (float64) 18345.97,
@@ -5797,7 +5797,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606181400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18485.11,
       (string) (len=4) "high": (float64) 18541.96,
       (string) (len=3) "low": (float64) 18472.37,
@@ -5809,7 +5809,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606183200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18436.39,
       (string) (len=4) "high": (float64) 18499.94,
       (string) (len=3) "low": (float64) 18386,
@@ -5821,7 +5821,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606185000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18360,
       (string) (len=4) "high": (float64) 18462.2,
       (string) (len=3) "low": (float64) 18360,
@@ -5833,7 +5833,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606186800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18400,
       (string) (len=4) "high": (float64) 18424.58,
       (string) (len=3) "low": (float64) 18343.25,
@@ -5845,7 +5845,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606188600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18367.39,
       (string) (len=4) "high": (float64) 18423.5,
       (string) (len=3) "low": (float64) 18343.65,
@@ -5857,7 +5857,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606190400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18355.21,
       (string) (len=4) "high": (float64) 18400.03,
       (string) (len=3) "low": (float64) 18327.23,
@@ -5869,7 +5869,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606192200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18462.67,
       (string) (len=4) "high": (float64) 18466.82,
       (string) (len=3) "low": (float64) 18307.01,
@@ -5881,7 +5881,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606194000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18373.52,
       (string) (len=4) "high": (float64) 18462.67,
       (string) (len=3) "low": (float64) 18350,
@@ -5893,7 +5893,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606195800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18350.13,
       (string) (len=4) "high": (float64) 18442.42,
       (string) (len=3) "low": (float64) 18318,
@@ -5905,7 +5905,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606197600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18349.98,
       (string) (len=4) "high": (float64) 18350.78,
       (string) (len=3) "low": (float64) 18052.02,
@@ -5917,7 +5917,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606199400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18413.67,
       (string) (len=4) "high": (float64) 18414.85,
       (string) (len=3) "low": (float64) 18264.49,
@@ -5929,7 +5929,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606201200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18447.28,
       (string) (len=4) "high": (float64) 18462.75,
       (string) (len=3) "low": (float64) 18391.81,
@@ -5941,7 +5941,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606203000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18392.39,
       (string) (len=4) "high": (float64) 18468.2,
       (string) (len=3) "low": (float64) 18383.67,
@@ -5953,7 +5953,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606204800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18477.57,
       (string) (len=4) "high": (float64) 18510.13,
       (string) (len=3) "low": (float64) 18392.39,
@@ -5965,7 +5965,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606206600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18638.75,
       (string) (len=4) "high": (float64) 18640.93,
       (string) (len=3) "low": (float64) 18472.98,
@@ -5977,7 +5977,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606208400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18889.13,
       (string) (len=4) "high": (float64) 18897.99,
       (string) (len=3) "low": (float64) 18572,
@@ -5989,7 +5989,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606210200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18982.53,
       (string) (len=4) "high": (float64) 19040,
       (string) (len=3) "low": (float64) 18730.18,
@@ -6001,7 +6001,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606212000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18767.77,
       (string) (len=4) "high": (float64) 19100,
       (string) (len=3) "low": (float64) 18703.5,
@@ -6013,7 +6013,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606213800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18896.6,
       (string) (len=4) "high": (float64) 18963.29,
       (string) (len=3) "low": (float64) 18715.25,
@@ -6025,7 +6025,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606215600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18939.93,
       (string) (len=4) "high": (float64) 19052,
       (string) (len=3) "low": (float64) 18855.92,
@@ -6037,7 +6037,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606217400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19077,
       (string) (len=4) "high": (float64) 19080,
       (string) (len=3) "low": (float64) 18921.03,
@@ -6049,7 +6049,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606219200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19140.92,
       (string) (len=4) "high": (float64) 19197.96,
       (string) (len=3) "low": (float64) 18975.79,
@@ -6061,7 +6061,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606221000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19195.8,
       (string) (len=4) "high": (float64) 19266.84,
       (string) (len=3) "low": (float64) 19073.27,
@@ -6073,7 +6073,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606222800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19269.34,
       (string) (len=4) "high": (float64) 19332.95,
       (string) (len=3) "low": (float64) 19184.52,
@@ -6085,7 +6085,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606224600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19205.04,
       (string) (len=4) "high": (float64) 19330.72,
       (string) (len=3) "low": (float64) 19122.3,
@@ -6097,7 +6097,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606226400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19281.33,
       (string) (len=4) "high": (float64) 19289.77,
       (string) (len=3) "low": (float64) 19126.5,
@@ -6109,7 +6109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606228200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19419.99,
       (string) (len=4) "high": (float64) 19420,
       (string) (len=3) "low": (float64) 19260.71,
@@ -6121,7 +6121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606230000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19350.28,
       (string) (len=4) "high": (float64) 19447,
       (string) (len=3) "low": (float64) 19327.13,
@@ -6133,7 +6133,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606231800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19392.68,
       (string) (len=4) "high": (float64) 19450,
       (string) (len=3) "low": (float64) 19273.24,
@@ -6145,7 +6145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606233600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19240.37,
       (string) (len=4) "high": (float64) 19469,
       (string) (len=3) "low": (float64) 19234.63,
@@ -6157,7 +6157,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606235400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19312.78,
       (string) (len=4) "high": (float64) 19339.92,
       (string) (len=3) "low": (float64) 19100.64,
@@ -6169,7 +6169,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606237200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19232.16,
       (string) (len=4) "high": (float64) 19367.69,
       (string) (len=3) "low": (float64) 19215.53,
@@ -6181,7 +6181,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606239000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19214.7,
       (string) (len=4) "high": (float64) 19318.85,
       (string) (len=3) "low": (float64) 19150.62,
@@ -6193,7 +6193,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606240800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19199.52,
       (string) (len=4) "high": (float64) 19276.47,
       (string) (len=3) "low": (float64) 19167.62,
@@ -6205,7 +6205,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606242600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19276.07,
       (string) (len=4) "high": (float64) 19285.01,
       (string) (len=3) "low": (float64) 19195.94,
@@ -6217,7 +6217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606244400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19285,
       (string) (len=4) "high": (float64) 19300,
       (string) (len=3) "low": (float64) 19242.4,
@@ -6229,7 +6229,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606246200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19168.01,
       (string) (len=4) "high": (float64) 19291.67,
       (string) (len=3) "low": (float64) 19168,
@@ -6241,7 +6241,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606248000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19094.16,
       (string) (len=4) "high": (float64) 19250,
       (string) (len=3) "low": (float64) 19000,
@@ -6253,7 +6253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606249800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19069.62,
       (string) (len=4) "high": (float64) 19110.16,
       (string) (len=3) "low": (float64) 18986,
@@ -6265,7 +6265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606251600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19030,
       (string) (len=4) "high": (float64) 19189,
       (string) (len=3) "low": (float64) 18918.64,
@@ -6277,7 +6277,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606253400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18944.42,
       (string) (len=4) "high": (float64) 19073.93,
       (string) (len=3) "low": (float64) 18853.08,
@@ -6289,7 +6289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606255200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19056.53,
       (string) (len=4) "high": (float64) 19085.19,
       (string) (len=3) "low": (float64) 18865.28,
@@ -6301,7 +6301,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606257000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19140.01,
       (string) (len=4) "high": (float64) 19147.59,
       (string) (len=3) "low": (float64) 19023.22,
@@ -6313,7 +6313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606258800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19142.01,
       (string) (len=4) "high": (float64) 19205,
       (string) (len=3) "low": (float64) 19118.15,
@@ -6325,7 +6325,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606260600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19172.84,
       (string) (len=4) "high": (float64) 19203.97,
       (string) (len=3) "low": (float64) 19103.35,
@@ -6337,7 +6337,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606262400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19161.78,
       (string) (len=4) "high": (float64) 19234.71,
       (string) (len=3) "low": (float64) 19140,
@@ -6349,7 +6349,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606264200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19180.87,
       (string) (len=4) "high": (float64) 19240.34,
       (string) (len=3) "low": (float64) 19156.21,
@@ -6361,7 +6361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606266000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19185,
       (string) (len=4) "high": (float64) 19225,
       (string) (len=3) "low": (float64) 19163.54,
@@ -6373,7 +6373,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606267800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19100.99,
       (string) (len=4) "high": (float64) 19185,
       (string) (len=3) "low": (float64) 19075.14,
@@ -6385,7 +6385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606269600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19010,
       (string) (len=4) "high": (float64) 19102.89,
       (string) (len=3) "low": (float64) 19001,
@@ -6397,7 +6397,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606271400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18985.13,
       (string) (len=4) "high": (float64) 19058.4,
       (string) (len=3) "low": (float64) 18912.28,
@@ -6409,7 +6409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606273200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19048.23,
       (string) (len=4) "high": (float64) 19049.47,
       (string) (len=3) "low": (float64) 18912.86,
@@ -6421,7 +6421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606275000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18826.13,
       (string) (len=4) "high": (float64) 19048.23,
       (string) (len=3) "low": (float64) 18751,
@@ -6433,7 +6433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606276800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18900.29,
       (string) (len=4) "high": (float64) 18918.48,
       (string) (len=3) "low": (float64) 18751,
@@ -6445,7 +6445,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606278600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18699.71,
       (string) (len=4) "high": (float64) 18931.66,
       (string) (len=3) "low": (float64) 18674.57,
@@ -6457,7 +6457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606280400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18825.07,
       (string) (len=4) "high": (float64) 18832.52,
       (string) (len=3) "low": (float64) 18641.59,
@@ -6469,7 +6469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606282200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18894.91,
       (string) (len=4) "high": (float64) 18903.68,
       (string) (len=3) "low": (float64) 18804.62,
@@ -6481,7 +6481,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606284000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18925.01,
       (string) (len=4) "high": (float64) 18960.54,
       (string) (len=3) "low": (float64) 18861.15,
@@ -6493,7 +6493,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606285800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18912.17,
       (string) (len=4) "high": (float64) 18939.16,
       (string) (len=3) "low": (float64) 18875,
@@ -6505,7 +6505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606287600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19007.91,
       (string) (len=4) "high": (float64) 19038.97,
       (string) (len=3) "low": (float64) 18851,
@@ -6517,7 +6517,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606289400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18992.58,
       (string) (len=4) "high": (float64) 19070,
       (string) (len=3) "low": (float64) 18987.2,
@@ -6529,7 +6529,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606291200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19190.5,
       (string) (len=4) "high": (float64) 19200,
       (string) (len=3) "low": (float64) 18990.05,
@@ -6541,7 +6541,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606293000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19133.4,
       (string) (len=4) "high": (float64) 19241.19,
       (string) (len=3) "low": (float64) 19127.41,
@@ -6553,7 +6553,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606294800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19144.96,
       (string) (len=4) "high": (float64) 19166.89,
       (string) (len=3) "low": (float64) 19077.84,
@@ -6565,7 +6565,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606296600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19167.51,
       (string) (len=4) "high": (float64) 19167.51,
       (string) (len=3) "low": (float64) 19078.33,
@@ -6577,7 +6577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606298400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19358.13,
       (string) (len=4) "high": (float64) 19360,
       (string) (len=3) "low": (float64) 19161.74,
@@ -6589,7 +6589,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606300200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19307.91,
       (string) (len=4) "high": (float64) 19358.26,
       (string) (len=3) "low": (float64) 19260.48,
@@ -6601,7 +6601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606302000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19313.81,
       (string) (len=4) "high": (float64) 19357.53,
       (string) (len=3) "low": (float64) 19283.2,
@@ -6613,7 +6613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606303800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19299.62,
       (string) (len=4) "high": (float64) 19359.96,
       (string) (len=3) "low": (float64) 19265.47,
@@ -6625,7 +6625,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606305600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19254.75,
       (string) (len=4) "high": (float64) 19326.87,
       (string) (len=3) "low": (float64) 19185.25,
@@ -6637,7 +6637,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606307400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19329.06,
       (string) (len=4) "high": (float64) 19342.85,
       (string) (len=3) "low": (float64) 19230,
@@ -6649,7 +6649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606309200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19263.07,
       (string) (len=4) "high": (float64) 19335.46,
       (string) (len=3) "low": (float64) 19202,
@@ -6661,7 +6661,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606311000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19216.27,
       (string) (len=4) "high": (float64) 19500,
       (string) (len=3) "low": (float64) 19123.88,
@@ -6673,7 +6673,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606312800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19165,
       (string) (len=4) "high": (float64) 19323.76,
       (string) (len=3) "low": (float64) 19131.25,
@@ -6685,7 +6685,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606314600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19298.21,
       (string) (len=4) "high": (float64) 19309.68,
       (string) (len=3) "low": (float64) 19131.24,
@@ -6697,7 +6697,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606316400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19323.56,
       (string) (len=4) "high": (float64) 19337.02,
       (string) (len=3) "low": (float64) 19227.95,
@@ -6709,7 +6709,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606318200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19140.04,
       (string) (len=4) "high": (float64) 19350,
       (string) (len=3) "low": (float64) 19138.11,
@@ -6721,7 +6721,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606320000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19019.66,
       (string) (len=4) "high": (float64) 19216.06,
       (string) (len=3) "low": (float64) 18913.59,
@@ -6733,7 +6733,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606321800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18995.84,
       (string) (len=4) "high": (float64) 19063.1,
       (string) (len=3) "low": (float64) 18875,
@@ -6745,7 +6745,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606323600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18909.58,
       (string) (len=4) "high": (float64) 19049.35,
       (string) (len=3) "low": (float64) 18901,
@@ -6757,7 +6757,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606325400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19073.75,
       (string) (len=4) "high": (float64) 19077.44,
       (string) (len=3) "low": (float64) 18830.58,
@@ -6769,7 +6769,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606327200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19121.69,
       (string) (len=4) "high": (float64) 19131.74,
       (string) (len=3) "low": (float64) 19042.99,
@@ -6781,7 +6781,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606329000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19061.81,
       (string) (len=4) "high": (float64) 19145.88,
       (string) (len=3) "low": (float64) 19049.97,
@@ -6793,7 +6793,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606330800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19012.3,
       (string) (len=4) "high": (float64) 19137.12,
       (string) (len=3) "low": (float64) 18974.38,
@@ -6805,7 +6805,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606332600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18990.56,
       (string) (len=4) "high": (float64) 19030.99,
       (string) (len=3) "low": (float64) 18906.05,
@@ -6817,7 +6817,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606334400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18913.38,
       (string) (len=4) "high": (float64) 19099.99,
       (string) (len=3) "low": (float64) 18867.11,
@@ -6829,7 +6829,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606336200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18910,
       (string) (len=4) "high": (float64) 18924.08,
       (string) (len=3) "low": (float64) 18727.63,
@@ -6841,7 +6841,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606338000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18981.12,
       (string) (len=4) "high": (float64) 19037.22,
       (string) (len=3) "low": (float64) 18850,
@@ -6853,7 +6853,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606339800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18881.52,
       (string) (len=4) "high": (float64) 19038.18,
       (string) (len=3) "low": (float64) 18831,
@@ -6865,7 +6865,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606341600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18823.12,
       (string) (len=4) "high": (float64) 18927,
       (string) (len=3) "low": (float64) 18750,
@@ -6877,7 +6877,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606343400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18766.58,
       (string) (len=4) "high": (float64) 18833.26,
       (string) (len=3) "low": (float64) 18708,
@@ -6889,7 +6889,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606345200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18731.54,
       (string) (len=4) "high": (float64) 18761.48,
       (string) (len=3) "low": (float64) 18502,
@@ -6901,7 +6901,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606347000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18721.93,
       (string) (len=4) "high": (float64) 18858.65,
       (string) (len=3) "low": (float64) 18707.03,
@@ -6913,7 +6913,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606348800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18865.64,
       (string) (len=4) "high": (float64) 18870.63,
       (string) (len=3) "low": (float64) 18600.31,
@@ -6925,7 +6925,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606350600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18869.59,
       (string) (len=4) "high": (float64) 18915.48,
       (string) (len=3) "low": (float64) 18810.25,
@@ -6937,7 +6937,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606352400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18807.09,
       (string) (len=4) "high": (float64) 18896.98,
       (string) (len=3) "low": (float64) 18785.48,
@@ -6949,7 +6949,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606354200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18804.06,
       (string) (len=4) "high": (float64) 18850.44,
       (string) (len=3) "low": (float64) 18745.69,
@@ -6961,7 +6961,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606356000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18550.91,
       (string) (len=4) "high": (float64) 18808.36,
       (string) (len=3) "low": (float64) 18505,
@@ -6973,7 +6973,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606357800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18409.83,
       (string) (len=4) "high": (float64) 18620,
       (string) (len=3) "low": (float64) 18350.51,
@@ -6985,7 +6985,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606359600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18121.46,
       (string) (len=4) "high": (float64) 18407.68,
       (string) (len=3) "low": (float64) 18037.51,
@@ -6997,7 +6997,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606361400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17952.19,
       (string) (len=4) "high": (float64) 18121.46,
       (string) (len=3) "low": (float64) 17150,
@@ -7009,7 +7009,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606363200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17855.14,
       (string) (len=4) "high": (float64) 18099.7,
       (string) (len=3) "low": (float64) 17768.27,
@@ -7021,7 +7021,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606365000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17767.8,
       (string) (len=4) "high": (float64) 17958.79,
       (string) (len=3) "low": (float64) 17552.6,
@@ -7033,7 +7033,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606366800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17710.56,
       (string) (len=4) "high": (float64) 17941.72,
       (string) (len=3) "low": (float64) 17690.01,
@@ -7045,7 +7045,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606368600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17929.59,
       (string) (len=4) "high": (float64) 17936.77,
       (string) (len=3) "low": (float64) 17690,
@@ -7057,7 +7057,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606370400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17991.55,
       (string) (len=4) "high": (float64) 18028.02,
       (string) (len=3) "low": (float64) 17833.72,
@@ -7069,7 +7069,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606372200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17968.09,
       (string) (len=4) "high": (float64) 17999,
       (string) (len=3) "low": (float64) 17879.92,
@@ -7081,7 +7081,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606374000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17765.17,
       (string) (len=4) "high": (float64) 17967.53,
       (string) (len=3) "low": (float64) 17730.01,
@@ -7093,7 +7093,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606375800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17589.93,
       (string) (len=4) "high": (float64) 17805.75,
       (string) (len=3) "low": (float64) 17445.92,
@@ -7105,7 +7105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606377600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17028.09,
       (string) (len=4) "high": (float64) 17579.98,
       (string) (len=3) "low": (float64) 16898.31,
@@ -7117,7 +7117,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606379400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16824.73,
       (string) (len=4) "high": (float64) 17028.1,
       (string) (len=3) "low": (float64) 16328.04,
@@ -7129,7 +7129,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606381200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16734.89,
       (string) (len=4) "high": (float64) 17116.84,
       (string) (len=3) "low": (float64) 16200,
@@ -7141,7 +7141,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606383000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17058.63,
       (string) (len=4) "high": (float64) 17131.07,
       (string) (len=3) "low": (float64) 16660.98,
@@ -7153,7 +7153,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606384800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17133.51,
       (string) (len=4) "high": (float64) 17316.61,
       (string) (len=3) "low": (float64) 17067.02,
@@ -7165,7 +7165,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606386600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17294.92,
       (string) (len=4) "high": (float64) 17303.9,
       (string) (len=3) "low": (float64) 17098.3,
@@ -7177,7 +7177,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606388400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17280.6,
       (string) (len=4) "high": (float64) 17433.81,
       (string) (len=3) "low": (float64) 17267.69,
@@ -7189,7 +7189,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606390200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17103.74,
       (string) (len=4) "high": (float64) 17355.26,
       (string) (len=3) "low": (float64) 16945,
@@ -7201,7 +7201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606392000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17332.07,
       (string) (len=4) "high": (float64) 17374.01,
       (string) (len=3) "low": (float64) 16981.87,
@@ -7213,7 +7213,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606393800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17393.06,
       (string) (len=4) "high": (float64) 17416.69,
       (string) (len=3) "low": (float64) 17175.33,
@@ -7225,7 +7225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606395600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17260.7,
       (string) (len=4) "high": (float64) 17418.73,
       (string) (len=3) "low": (float64) 17221.86,
@@ -7237,7 +7237,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606397400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17064.1,
       (string) (len=4) "high": (float64) 17357.33,
       (string) (len=3) "low": (float64) 17048.22,
@@ -7249,7 +7249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606399200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16849.09,
       (string) (len=4) "high": (float64) 17129.86,
       (string) (len=3) "low": (float64) 16755.01,
@@ -7261,7 +7261,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606401000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16776.49,
       (string) (len=4) "high": (float64) 16960.4,
       (string) (len=3) "low": (float64) 16610.1,
@@ -7273,7 +7273,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606402800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17164.67,
       (string) (len=4) "high": (float64) 17249.99,
       (string) (len=3) "low": (float64) 16610.1,
@@ -7285,7 +7285,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606404600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16912.74,
       (string) (len=4) "high": (float64) 17215.51,
       (string) (len=3) "low": (float64) 16855.11,
@@ -7297,7 +7297,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606406400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16941.93,
       (string) (len=4) "high": (float64) 17045.03,
       (string) (len=3) "low": (float64) 16800.72,
@@ -7309,7 +7309,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606408200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16669.43,
       (string) (len=4) "high": (float64) 16984.02,
       (string) (len=3) "low": (float64) 16500,
@@ -7321,7 +7321,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606410000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16297.09,
       (string) (len=4) "high": (float64) 16669.46,
       (string) (len=3) "low": (float64) 16200.02,
@@ -7333,7 +7333,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606411800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16719.86,
       (string) (len=4) "high": (float64) 16749.72,
       (string) (len=3) "low": (float64) 16289.45,
@@ -7345,7 +7345,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606413600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16684,
       (string) (len=4) "high": (float64) 16818.08,
       (string) (len=3) "low": (float64) 16609.13,
@@ -7357,7 +7357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606415400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16550,
       (string) (len=4) "high": (float64) 16848.2,
       (string) (len=3) "low": (float64) 16528.6,
@@ -7369,7 +7369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606417200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16370.4,
       (string) (len=4) "high": (float64) 16605.92,
       (string) (len=3) "low": (float64) 16300,
@@ -7381,7 +7381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606419000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16533.46,
       (string) (len=4) "high": (float64) 16641.88,
       (string) (len=3) "low": (float64) 16332.17,
@@ -7393,7 +7393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606420800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16859.93,
       (string) (len=4) "high": (float64) 16970.61,
       (string) (len=3) "low": (float64) 16519.1,
@@ -7405,7 +7405,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606422600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17179.46,
       (string) (len=4) "high": (float64) 17200,
       (string) (len=3) "low": (float64) 16850.78,
@@ -7417,7 +7417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606424400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17138.56,
       (string) (len=4) "high": (float64) 17344.09,
       (string) (len=3) "low": (float64) 17076.9,
@@ -7429,7 +7429,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606426200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17050.01,
       (string) (len=4) "high": (float64) 17233.7,
       (string) (len=3) "low": (float64) 17042.22,
@@ -7441,7 +7441,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606428000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17175.11,
       (string) (len=4) "high": (float64) 17181.95,
       (string) (len=3) "low": (float64) 17001,
@@ -7453,7 +7453,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606429800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17192.1,
       (string) (len=4) "high": (float64) 17250.93,
       (string) (len=3) "low": (float64) 17100.28,
@@ -7465,7 +7465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606431600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17138.36,
       (string) (len=4) "high": (float64) 17201.12,
       (string) (len=3) "low": (float64) 16950.66,
@@ -7477,7 +7477,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606433400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17170,
       (string) (len=4) "high": (float64) 17182.09,
       (string) (len=3) "low": (float64) 17064.67,
@@ -7489,7 +7489,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606435200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17134.99,
       (string) (len=4) "high": (float64) 17199.01,
       (string) (len=3) "low": (float64) 17040.71,
@@ -7501,7 +7501,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606437000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17408.2,
       (string) (len=4) "high": (float64) 17424,
       (string) (len=3) "low": (float64) 17134.99,
@@ -7513,7 +7513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606438800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17368.46,
       (string) (len=4) "high": (float64) 17475,
       (string) (len=3) "low": (float64) 17346.81,
@@ -7525,7 +7525,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606440600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17327.67,
       (string) (len=4) "high": (float64) 17454.02,
       (string) (len=3) "low": (float64) 17289.99,
@@ -7537,7 +7537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606442400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17291.8,
       (string) (len=4) "high": (float64) 17340,
       (string) (len=3) "low": (float64) 17161.01,
@@ -7549,7 +7549,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606444200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17103.91,
       (string) (len=4) "high": (float64) 17304.07,
       (string) (len=3) "low": (float64) 17082,
@@ -7561,7 +7561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606446000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17238.16,
       (string) (len=4) "high": (float64) 17280,
       (string) (len=3) "low": (float64) 17106.92,
@@ -7573,7 +7573,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606447800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17096,
       (string) (len=4) "high": (float64) 17287.69,
       (string) (len=3) "low": (float64) 17035.82,
@@ -7585,7 +7585,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606449600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17157.94,
       (string) (len=4) "high": (float64) 17196.4,
       (string) (len=3) "low": (float64) 17075.54,
@@ -7597,7 +7597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606451400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17083.18,
       (string) (len=4) "high": (float64) 17170.43,
       (string) (len=3) "low": (float64) 17063.69,
@@ -7609,7 +7609,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606453200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17259.14,
       (string) (len=4) "high": (float64) 17313.8,
       (string) (len=3) "low": (float64) 17085.11,
@@ -7621,7 +7621,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606455000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17272.42,
       (string) (len=4) "high": (float64) 17356.3,
       (string) (len=3) "low": (float64) 17220.19,
@@ -7633,7 +7633,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606456800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17220.23,
       (string) (len=4) "high": (float64) 17309.15,
       (string) (len=3) "low": (float64) 17182.87,
@@ -7645,7 +7645,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606458600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17296.87,
       (string) (len=4) "high": (float64) 17323.96,
       (string) (len=3) "low": (float64) 17220.22,
@@ -7657,7 +7657,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606460400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17141.13,
       (string) (len=4) "high": (float64) 17309.71,
       (string) (len=3) "low": (float64) 17109.34,
@@ -7669,7 +7669,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606462200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17090.67,
       (string) (len=4) "high": (float64) 17167.72,
       (string) (len=3) "low": (float64) 17040.01,
@@ -7681,7 +7681,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606464000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16746.46,
       (string) (len=4) "high": (float64) 17108.13,
       (string) (len=3) "low": (float64) 16735.41,
@@ -7693,7 +7693,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606465800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16843.01,
       (string) (len=4) "high": (float64) 16895.4,
       (string) (len=3) "low": (float64) 16721,
@@ -7705,7 +7705,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606467600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16791.65,
       (string) (len=4) "high": (float64) 17200,
       (string) (len=3) "low": (float64) 16674.23,
@@ -7717,7 +7717,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606469400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16640.05,
       (string) (len=4) "high": (float64) 16840.7,
       (string) (len=3) "low": (float64) 16592.46,
@@ -7729,7 +7729,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606471200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16795.26,
       (string) (len=4) "high": (float64) 16879.64,
       (string) (len=3) "low": (float64) 16639.31,
@@ -7741,7 +7741,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606473000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16905.25,
       (string) (len=4) "high": (float64) 16933.67,
       (string) (len=3) "low": (float64) 16702.6,
@@ -7753,7 +7753,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606474800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16856.49,
       (string) (len=4) "high": (float64) 16927.9,
       (string) (len=3) "low": (float64) 16775.91,
@@ -7765,7 +7765,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606476600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16783.86,
       (string) (len=4) "high": (float64) 16852.16,
       (string) (len=3) "low": (float64) 16735.17,
@@ -7777,7 +7777,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606478400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16893.96,
       (string) (len=4) "high": (float64) 16932.75,
       (string) (len=3) "low": (float64) 16770,
@@ -7789,7 +7789,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606480200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17069.19,
       (string) (len=4) "high": (float64) 17074.38,
       (string) (len=3) "low": (float64) 16890.91,
@@ -7801,7 +7801,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606482000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17000.01,
       (string) (len=4) "high": (float64) 17077.81,
       (string) (len=3) "low": (float64) 16973.27,
@@ -7813,7 +7813,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606483800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16942.61,
       (string) (len=4) "high": (float64) 17034.62,
       (string) (len=3) "low": (float64) 16910.74,
@@ -7825,7 +7825,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606485600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16844.24,
       (string) (len=4) "high": (float64) 16958.2,
       (string) (len=3) "low": (float64) 16767.71,
@@ -7837,7 +7837,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606487400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16760.51,
       (string) (len=4) "high": (float64) 16944.84,
       (string) (len=3) "low": (float64) 16725.57,
@@ -7849,7 +7849,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606489200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16664.34,
       (string) (len=4) "high": (float64) 16775.85,
       (string) (len=3) "low": (float64) 16617.61,
@@ -7861,7 +7861,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606491000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16494.26,
       (string) (len=4) "high": (float64) 16722.7,
       (string) (len=3) "low": (float64) 16400,
@@ -7873,7 +7873,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606492800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16703.38,
       (string) (len=4) "high": (float64) 16762.78,
       (string) (len=3) "low": (float64) 16459.35,
@@ -7885,7 +7885,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606494600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16823.01,
       (string) (len=4) "high": (float64) 16845.02,
       (string) (len=3) "low": (float64) 16659.69,
@@ -7897,7 +7897,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606496400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16758.85,
       (string) (len=4) "high": (float64) 16823,
       (string) (len=3) "low": (float64) 16745,
@@ -7909,7 +7909,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606498200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16737.45,
       (string) (len=4) "high": (float64) 16769.01,
       (string) (len=3) "low": (float64) 16670.02,
@@ -7921,7 +7921,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606500000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16820.01,
       (string) (len=4) "high": (float64) 16870.01,
       (string) (len=3) "low": (float64) 16698,
@@ -7933,7 +7933,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606501800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16790.52,
       (string) (len=4) "high": (float64) 16850,
       (string) (len=3) "low": (float64) 16761.17,
@@ -7945,7 +7945,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606503600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16763.11,
       (string) (len=4) "high": (float64) 16855,
       (string) (len=3) "low": (float64) 16757.81,
@@ -7957,7 +7957,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606505400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16816,
       (string) (len=4) "high": (float64) 16823.23,
       (string) (len=3) "low": (float64) 16722.9,
@@ -7969,7 +7969,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606507200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17045.9,
       (string) (len=4) "high": (float64) 17069.03,
       (string) (len=3) "low": (float64) 16751.38,
@@ -7981,7 +7981,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606509000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17078.7,
       (string) (len=4) "high": (float64) 17137.09,
       (string) (len=3) "low": (float64) 17016.34,
@@ -7993,7 +7993,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606510800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17010.02,
       (string) (len=4) "high": (float64) 17095.29,
       (string) (len=3) "low": (float64) 17010.01,
@@ -8005,7 +8005,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606512600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17002.85,
       (string) (len=4) "high": (float64) 17031.12,
       (string) (len=3) "low": (float64) 16905.5,
@@ -8017,7 +8017,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606514400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16971.44,
       (string) (len=4) "high": (float64) 17056.97,
       (string) (len=3) "low": (float64) 16935.33,
@@ -8029,7 +8029,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606516200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16976.33,
       (string) (len=4) "high": (float64) 17029.7,
       (string) (len=3) "low": (float64) 16930.22,
@@ -8041,7 +8041,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606518000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17070.82,
       (string) (len=4) "high": (float64) 17088.06,
       (string) (len=3) "low": (float64) 16975.53,
@@ -8053,7 +8053,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606519800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17153.95,
       (string) (len=4) "high": (float64) 17165.86,
       (string) (len=3) "low": (float64) 17062.6,
@@ -8065,7 +8065,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606521600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17092.33,
       (string) (len=4) "high": (float64) 17181.91,
       (string) (len=3) "low": (float64) 16989.13,
@@ -8077,7 +8077,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606523400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17168.77,
       (string) (len=4) "high": (float64) 17176.28,
       (string) (len=3) "low": (float64) 17061.13,
@@ -8089,7 +8089,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606525200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17175.68,
       (string) (len=4) "high": (float64) 17198,
       (string) (len=3) "low": (float64) 17085.79,
@@ -8101,7 +8101,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606527000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17149.63,
       (string) (len=4) "high": (float64) 17195.28,
       (string) (len=3) "low": (float64) 17064.01,
@@ -8113,7 +8113,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606528800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17065.1,
       (string) (len=4) "high": (float64) 17149.97,
       (string) (len=3) "low": (float64) 17034.39,
@@ -8125,7 +8125,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606530600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17000.71,
       (string) (len=4) "high": (float64) 17090.61,
       (string) (len=3) "low": (float64) 17000,
@@ -8137,7 +8137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606532400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16956.37,
       (string) (len=4) "high": (float64) 17027.85,
       (string) (len=3) "low": (float64) 16938.52,
@@ -8149,7 +8149,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606534200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17010.3,
       (string) (len=4) "high": (float64) 17027.97,
       (string) (len=3) "low": (float64) 16950,
@@ -8161,7 +8161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606536000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16979.99,
       (string) (len=4) "high": (float64) 17045.73,
       (string) (len=3) "low": (float64) 16956.93,
@@ -8173,7 +8173,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606537800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16973.53,
       (string) (len=4) "high": (float64) 16988.98,
       (string) (len=3) "low": (float64) 16907.8,
@@ -8185,7 +8185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606539600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16899.39,
       (string) (len=4) "high": (float64) 16989.03,
       (string) (len=3) "low": (float64) 16882.33,
@@ -8197,7 +8197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606541400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16989.03,
       (string) (len=4) "high": (float64) 16989.03,
       (string) (len=3) "low": (float64) 16888.35,
@@ -8209,7 +8209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606543200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17008.97,
       (string) (len=4) "high": (float64) 17053.05,
       (string) (len=3) "low": (float64) 16978.26,
@@ -8221,7 +8221,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606545000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17029.47,
       (string) (len=4) "high": (float64) 17029.47,
       (string) (len=3) "low": (float64) 16975.29,
@@ -8233,7 +8233,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606546800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17041.53,
       (string) (len=4) "high": (float64) 17075.81,
       (string) (len=3) "low": (float64) 17026.15,
@@ -8245,7 +8245,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606548600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17025.92,
       (string) (len=4) "high": (float64) 17073.76,
       (string) (len=3) "low": (float64) 17003.55,
@@ -8257,7 +8257,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606550400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16911.12,
       (string) (len=4) "high": (float64) 17057.9,
       (string) (len=3) "low": (float64) 16905.94,
@@ -8269,7 +8269,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606552200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16889.6,
       (string) (len=4) "high": (float64) 16938.5,
       (string) (len=3) "low": (float64) 16880,
@@ -8281,7 +8281,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606554000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16956.92,
       (string) (len=4) "high": (float64) 16967.97,
       (string) (len=3) "low": (float64) 16885.8,
@@ -8293,7 +8293,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606555800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16927.18,
       (string) (len=4) "high": (float64) 16974.37,
       (string) (len=3) "low": (float64) 16915.84,
@@ -8305,7 +8305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606557600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17132.51,
       (string) (len=4) "high": (float64) 17135.95,
       (string) (len=3) "low": (float64) 16890.32,
@@ -8317,7 +8317,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606559400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17199.77,
       (string) (len=4) "high": (float64) 17252.96,
       (string) (len=3) "low": (float64) 17100.69,
@@ -8329,7 +8329,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606561200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17120.03,
       (string) (len=4) "high": (float64) 17200,
       (string) (len=3) "low": (float64) 17104.91,
@@ -8341,7 +8341,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606563000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17164.46,
       (string) (len=4) "high": (float64) 17198.1,
       (string) (len=3) "low": (float64) 17120.03,
@@ -8353,7 +8353,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606564800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17162.16,
       (string) (len=4) "high": (float64) 17231.75,
       (string) (len=3) "low": (float64) 17129.71,
@@ -8365,7 +8365,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606566600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17143.02,
       (string) (len=4) "high": (float64) 17172.7,
       (string) (len=3) "low": (float64) 17071.71,
@@ -8377,7 +8377,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606568400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17219.34,
       (string) (len=4) "high": (float64) 17221.13,
       (string) (len=3) "low": (float64) 17087.72,
@@ -8389,7 +8389,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606570200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17370.99,
       (string) (len=4) "high": (float64) 17374.21,
       (string) (len=3) "low": (float64) 17212.4,
@@ -8401,7 +8401,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606572000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17343.13,
       (string) (len=4) "high": (float64) 17411.26,
       (string) (len=3) "low": (float64) 17322.58,
@@ -8413,7 +8413,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606573800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17351.51,
       (string) (len=4) "high": (float64) 17373.56,
       (string) (len=3) "low": (float64) 17277.24,
@@ -8425,7 +8425,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606575600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17383.91,
       (string) (len=4) "high": (float64) 17444.88,
       (string) (len=3) "low": (float64) 17350.82,
@@ -8437,7 +8437,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606577400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17533.05,
       (string) (len=4) "high": (float64) 17534.03,
       (string) (len=3) "low": (float64) 17355.75,
@@ -8449,7 +8449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606579200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17666.57,
       (string) (len=4) "high": (float64) 17749.49,
       (string) (len=3) "low": (float64) 17533.04,
@@ -8461,7 +8461,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606581000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17731.58,
       (string) (len=4) "high": (float64) 17789,
       (string) (len=3) "low": (float64) 17668.48,
@@ -8473,7 +8473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606582800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17707.56,
       (string) (len=4) "high": (float64) 17768.74,
       (string) (len=3) "low": (float64) 17588.66,
@@ -8485,7 +8485,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606584600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17768.94,
       (string) (len=4) "high": (float64) 17771.11,
       (string) (len=3) "low": (float64) 17686.59,
@@ -8497,7 +8497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606586400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17701.58,
       (string) (len=4) "high": (float64) 17787.54,
       (string) (len=3) "low": (float64) 17700,
@@ -8509,7 +8509,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606588200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17742.11,
       (string) (len=4) "high": (float64) 17762.19,
       (string) (len=3) "low": (float64) 17670.3,
@@ -8521,7 +8521,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606590000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17719.34,
       (string) (len=4) "high": (float64) 17758.64,
       (string) (len=3) "low": (float64) 17692.92,
@@ -8533,7 +8533,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606591800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17843.78,
       (string) (len=4) "high": (float64) 17933.25,
       (string) (len=3) "low": (float64) 17714.79,
@@ -8545,7 +8545,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606593600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17807.74,
       (string) (len=4) "high": (float64) 17902.88,
       (string) (len=3) "low": (float64) 17789.46,
@@ -8557,7 +8557,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606595400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17692.45,
       (string) (len=4) "high": (float64) 17847.31,
       (string) (len=3) "low": (float64) 17692.45,
@@ -8569,7 +8569,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606597200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17724.62,
       (string) (len=4) "high": (float64) 17772.06,
       (string) (len=3) "low": (float64) 17685,
@@ -8581,7 +8581,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606599000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17762.22,
       (string) (len=4) "high": (float64) 17770,
       (string) (len=3) "low": (float64) 17701.57,
@@ -8593,7 +8593,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606600800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17685.01,
       (string) (len=4) "high": (float64) 17774.5,
       (string) (len=3) "low": (float64) 17652,
@@ -8605,7 +8605,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606602600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17777.36,
       (string) (len=4) "high": (float64) 17849.99,
       (string) (len=3) "low": (float64) 17685,
@@ -8617,7 +8617,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606604400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17796.6,
       (string) (len=4) "high": (float64) 17821.47,
       (string) (len=3) "low": (float64) 17753.34,
@@ -8629,7 +8629,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606606200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17739.85,
       (string) (len=4) "high": (float64) 17796.89,
       (string) (len=3) "low": (float64) 17680,
@@ -8641,7 +8641,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606608000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17564.83,
       (string) (len=4) "high": (float64) 17781.46,
       (string) (len=3) "low": (float64) 17549.11,
@@ -8653,7 +8653,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606609800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17668.84,
       (string) (len=4) "high": (float64) 17669.02,
       (string) (len=3) "low": (float64) 17550.86,
@@ -8665,7 +8665,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606611600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17581.3,
       (string) (len=4) "high": (float64) 17680.69,
       (string) (len=3) "low": (float64) 17581.18,
@@ -8677,7 +8677,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606613400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17599,
       (string) (len=4) "high": (float64) 17646.99,
       (string) (len=3) "low": (float64) 17535.26,
@@ -8689,7 +8689,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606615200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17647.84,
       (string) (len=4) "high": (float64) 17684.1,
       (string) (len=3) "low": (float64) 17556,
@@ -8701,7 +8701,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606617000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17758.89,
       (string) (len=4) "high": (float64) 17765.76,
       (string) (len=3) "low": (float64) 17637.05,
@@ -8713,7 +8713,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606618800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17780.01,
       (string) (len=4) "high": (float64) 17816.99,
       (string) (len=3) "low": (float64) 17743.19,
@@ -8725,7 +8725,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606620600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17887.22,
       (string) (len=4) "high": (float64) 17900,
       (string) (len=3) "low": (float64) 17763.81,
@@ -8737,7 +8737,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606622400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17808.78,
       (string) (len=4) "high": (float64) 17884.61,
       (string) (len=3) "low": (float64) 17800.01,
@@ -8749,7 +8749,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606624200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17778.49,
       (string) (len=4) "high": (float64) 17828.61,
       (string) (len=3) "low": (float64) 17770.96,
@@ -8761,7 +8761,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606626000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17823.56,
       (string) (len=4) "high": (float64) 17847.48,
       (string) (len=3) "low": (float64) 17760.31,
@@ -8773,7 +8773,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606627800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17807.76,
       (string) (len=4) "high": (float64) 17848.38,
       (string) (len=3) "low": (float64) 17800,
@@ -8785,7 +8785,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606629600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17740.55,
       (string) (len=4) "high": (float64) 17809.34,
       (string) (len=3) "low": (float64) 17728.24,
@@ -8797,7 +8797,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606631400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17743.85,
       (string) (len=4) "high": (float64) 17795.88,
       (string) (len=3) "low": (float64) 17732.2,
@@ -8809,7 +8809,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606633200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17822,
       (string) (len=4) "high": (float64) 17822,
       (string) (len=3) "low": (float64) 17686.91,
@@ -8821,7 +8821,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606635000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17829.18,
       (string) (len=4) "high": (float64) 17857.78,
       (string) (len=3) "low": (float64) 17795,
@@ -8833,7 +8833,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606636800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18108.92,
       (string) (len=4) "high": (float64) 18132.27,
       (string) (len=3) "low": (float64) 17815.11,
@@ -8845,7 +8845,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606638600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18157.54,
       (string) (len=4) "high": (float64) 18165.05,
       (string) (len=3) "low": (float64) 18036.54,
@@ -8857,7 +8857,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606640400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18176.63,
       (string) (len=4) "high": (float64) 18199,
       (string) (len=3) "low": (float64) 18060.15,
@@ -8869,7 +8869,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606642200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18113,
       (string) (len=4) "high": (float64) 18230,
       (string) (len=3) "low": (float64) 18072.99,
@@ -8881,7 +8881,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606644000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18147.91,
       (string) (len=4) "high": (float64) 18154.39,
       (string) (len=3) "low": (float64) 18050.01,
@@ -8893,7 +8893,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606645800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18198.66,
       (string) (len=4) "high": (float64) 18230.33,
       (string) (len=3) "low": (float64) 18100.24,
@@ -8905,7 +8905,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606647600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18086.48,
       (string) (len=4) "high": (float64) 18248.21,
       (string) (len=3) "low": (float64) 18064.22,
@@ -8917,7 +8917,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606649400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18098.98,
       (string) (len=4) "high": (float64) 18121.1,
       (string) (len=3) "low": (float64) 18018.53,
@@ -8929,7 +8929,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606651200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18036.71,
       (string) (len=4) "high": (float64) 18145.25,
       (string) (len=3) "low": (float64) 17950,
@@ -8941,7 +8941,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606653000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18038.78,
       (string) (len=4) "high": (float64) 18090,
       (string) (len=3) "low": (float64) 17915.94,
@@ -8953,7 +8953,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606654800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18097.56,
       (string) (len=4) "high": (float64) 18139.87,
       (string) (len=3) "low": (float64) 18020,
@@ -8965,7 +8965,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606656600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18112.58,
       (string) (len=4) "high": (float64) 18112.58,
       (string) (len=3) "low": (float64) 18029.81,
@@ -8977,7 +8977,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606658400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18129.32,
       (string) (len=4) "high": (float64) 18208.87,
       (string) (len=3) "low": (float64) 18107.83,
@@ -8989,7 +8989,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606660200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18055.21,
       (string) (len=4) "high": (float64) 18131.5,
       (string) (len=3) "low": (float64) 18045.53,
@@ -9001,7 +9001,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606662000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18122.94,
       (string) (len=4) "high": (float64) 18149.1,
       (string) (len=3) "low": (float64) 17985,
@@ -9013,7 +9013,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606663800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18130.35,
       (string) (len=4) "high": (float64) 18165.27,
       (string) (len=3) "low": (float64) 18056.46,
@@ -9025,7 +9025,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606665600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18005.9,
       (string) (len=4) "high": (float64) 18165,
       (string) (len=3) "low": (float64) 17947.22,
@@ -9037,7 +9037,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606667400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18112.12,
       (string) (len=4) "high": (float64) 18115.72,
       (string) (len=3) "low": (float64) 17964.04,
@@ -9049,7 +9049,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606669200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18117.92,
       (string) (len=4) "high": (float64) 18140.01,
       (string) (len=3) "low": (float64) 18075.01,
@@ -9061,7 +9061,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606671000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18114.9,
       (string) (len=4) "high": (float64) 18160,
       (string) (len=3) "low": (float64) 18080,
@@ -9073,7 +9073,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606672800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18071.22,
       (string) (len=4) "high": (float64) 18117.03,
       (string) (len=3) "low": (float64) 18064,
@@ -9085,7 +9085,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606674600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18136.22,
       (string) (len=4) "high": (float64) 18145,
       (string) (len=3) "low": (float64) 18070.04,
@@ -9097,7 +9097,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606676400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18068.82,
       (string) (len=4) "high": (float64) 18145,
       (string) (len=3) "low": (float64) 18066.07,
@@ -9109,7 +9109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606678200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18066.69,
       (string) (len=4) "high": (float64) 18110.27,
       (string) (len=3) "low": (float64) 18035.5,
@@ -9121,7 +9121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606680000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18180.01,
       (string) (len=4) "high": (float64) 18194.99,
       (string) (len=3) "low": (float64) 18046.39,
@@ -9133,7 +9133,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606681800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18228.37,
       (string) (len=4) "high": (float64) 18242.54,
       (string) (len=3) "low": (float64) 18152.52,
@@ -9145,7 +9145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606683600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18300.06,
       (string) (len=4) "high": (float64) 18359,
       (string) (len=3) "low": (float64) 18220.17,
@@ -9157,7 +9157,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606685400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18274.99,
       (string) (len=4) "high": (float64) 18337.26,
       (string) (len=3) "low": (float64) 18261,
@@ -9169,7 +9169,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606687200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18130.01,
       (string) (len=4) "high": (float64) 18289.31,
       (string) (len=3) "low": (float64) 18079.49,
@@ -9181,7 +9181,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606689000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18158.13,
       (string) (len=4) "high": (float64) 18220.46,
       (string) (len=3) "low": (float64) 18084.53,
@@ -9193,7 +9193,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606690800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18224.54,
       (string) (len=4) "high": (float64) 18258.22,
       (string) (len=3) "low": (float64) 18140.01,
@@ -9205,7 +9205,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606692600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18202.04,
       (string) (len=4) "high": (float64) 18223.13,
       (string) (len=3) "low": (float64) 18150,
@@ -9217,7 +9217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606694400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18399.99,
       (string) (len=4) "high": (float64) 18400,
       (string) (len=3) "low": (float64) 18201.47,
@@ -9229,7 +9229,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606696200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18454.01,
       (string) (len=4) "high": (float64) 18490,
       (string) (len=3) "low": (float64) 18383.38,
@@ -9241,7 +9241,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606698000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18405.87,
       (string) (len=4) "high": (float64) 18516.36,
       (string) (len=3) "low": (float64) 18369.1,
@@ -9253,7 +9253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606699800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18501.08,
       (string) (len=4) "high": (float64) 18564.31,
       (string) (len=3) "low": (float64) 18396.7,
@@ -9265,7 +9265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606701600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18514.77,
       (string) (len=4) "high": (float64) 18545.37,
       (string) (len=3) "low": (float64) 18459.46,
@@ -9277,7 +9277,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606703400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18528.36,
       (string) (len=4) "high": (float64) 18574.46,
       (string) (len=3) "low": (float64) 18469.01,
@@ -9289,7 +9289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606705200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18591.03,
       (string) (len=4) "high": (float64) 18597.79,
       (string) (len=3) "low": (float64) 18460,
@@ -9301,7 +9301,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606707000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18606.02,
       (string) (len=4) "high": (float64) 18612.87,
       (string) (len=3) "low": (float64) 18513.55,
@@ -9313,7 +9313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606708800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18491.51,
       (string) (len=4) "high": (float64) 18636.77,
       (string) (len=3) "low": (float64) 18481.24,
@@ -9325,7 +9325,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606710600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18542.16,
       (string) (len=4) "high": (float64) 18562.11,
       (string) (len=3) "low": (float64) 18472.68,
@@ -9337,7 +9337,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606712400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18625,
       (string) (len=4) "high": (float64) 18625,
       (string) (len=3) "low": (float64) 18499,
@@ -9349,7 +9349,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606714200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18539.96,
       (string) (len=4) "high": (float64) 18640,
       (string) (len=3) "low": (float64) 18530.68,
@@ -9361,7 +9361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606716000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18506.47,
       (string) (len=4) "high": (float64) 18578.79,
       (string) (len=3) "low": (float64) 18505.41,
@@ -9373,7 +9373,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606717800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18549.66,
       (string) (len=4) "high": (float64) 18566.66,
       (string) (len=3) "low": (float64) 18494.72,
@@ -9385,7 +9385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606719600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18684.85,
       (string) (len=4) "high": (float64) 18693.43,
       (string) (len=3) "low": (float64) 18545.5,
@@ -9397,7 +9397,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606721400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18634.68,
       (string) (len=4) "high": (float64) 18694.96,
       (string) (len=3) "low": (float64) 18596.77,
@@ -9409,7 +9409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606723200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18442.55,
       (string) (len=4) "high": (float64) 18634.73,
       (string) (len=3) "low": (float64) 18400,
@@ -9421,7 +9421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606725000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18477.05,
       (string) (len=4) "high": (float64) 18536.99,
       (string) (len=3) "low": (float64) 18431.27,
@@ -9433,7 +9433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606726800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18417.55,
       (string) (len=4) "high": (float64) 18523.63,
       (string) (len=3) "low": (float64) 18412.28,
@@ -9445,7 +9445,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606728600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18493.43,
       (string) (len=4) "high": (float64) 18500.26,
       (string) (len=3) "low": (float64) 18345.72,
@@ -9457,7 +9457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606730400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18556.87,
       (string) (len=4) "high": (float64) 18569.15,
       (string) (len=3) "low": (float64) 18467.57,
@@ -9469,7 +9469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606732200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18512.3,
       (string) (len=4) "high": (float64) 18591.21,
       (string) (len=3) "low": (float64) 18512.3,
@@ -9481,7 +9481,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606734000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18640.94,
       (string) (len=4) "high": (float64) 18664.56,
       (string) (len=3) "low": (float64) 18512.3,
@@ -9493,7 +9493,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606735800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18611.27,
       (string) (len=4) "high": (float64) 18675,
       (string) (len=3) "low": (float64) 18596.95,
@@ -9505,7 +9505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606737600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18782.07,
       (string) (len=4) "high": (float64) 18819.34,
       (string) (len=3) "low": (float64) 18612.41,
@@ -9517,7 +9517,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606739400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18860.9,
       (string) (len=4) "high": (float64) 18861.11,
       (string) (len=3) "low": (float64) 18739.72,
@@ -9529,7 +9529,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606741200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18949.99,
       (string) (len=4) "high": (float64) 18950,
       (string) (len=3) "low": (float64) 18812.12,
@@ -9541,7 +9541,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606743000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19175.71,
       (string) (len=4) "high": (float64) 19239.33,
       (string) (len=3) "low": (float64) 18891.69,
@@ -9553,7 +9553,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606744800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19290,
       (string) (len=4) "high": (float64) 19350.01,
       (string) (len=3) "low": (float64) 19139.74,
@@ -9565,7 +9565,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606746600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19500,
       (string) (len=4) "high": (float64) 19829.47,
       (string) (len=3) "low": (float64) 19222.11,
@@ -9577,7 +9577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606748400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19677.96,
       (string) (len=4) "high": (float64) 19873.23,
       (string) (len=3) "low": (float64) 19502.05,
@@ -9589,7 +9589,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606750200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19281.35,
       (string) (len=4) "high": (float64) 19699.95,
       (string) (len=3) "low": (float64) 19135.18,
@@ -9601,7 +9601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606752000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19513.62,
       (string) (len=4) "high": (float64) 19588.53,
       (string) (len=3) "low": (float64) 19277.04,
@@ -9613,7 +9613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606753800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19185.35,
       (string) (len=4) "high": (float64) 19525.87,
       (string) (len=3) "low": (float64) 19111.93,
@@ -9625,7 +9625,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606755600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19282.49,
       (string) (len=4) "high": (float64) 19325.77,
       (string) (len=3) "low": (float64) 18998.66,
@@ -9637,7 +9637,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606757400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19392.04,
       (string) (len=4) "high": (float64) 19467.48,
       (string) (len=3) "low": (float64) 19279.7,
@@ -9649,7 +9649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606759200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19242.23,
       (string) (len=4) "high": (float64) 19474.69,
       (string) (len=3) "low": (float64) 19184.75,
@@ -9661,7 +9661,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606761000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19186.78,
       (string) (len=4) "high": (float64) 19348.39,
       (string) (len=3) "low": (float64) 19164.46,
@@ -9673,7 +9673,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606762800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19300.72,
       (string) (len=4) "high": (float64) 19310,
       (string) (len=3) "low": (float64) 19106.29,
@@ -9685,7 +9685,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606764600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19262.72,
       (string) (len=4) "high": (float64) 19314.32,
       (string) (len=3) "low": (float64) 19134.98,
@@ -9697,7 +9697,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606766400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19422.57,
       (string) (len=4) "high": (float64) 19435.83,
       (string) (len=3) "low": (float64) 19172.31,
@@ -9709,7 +9709,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606768200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19439.79,
       (string) (len=4) "high": (float64) 19490.04,
       (string) (len=3) "low": (float64) 19382.01,
@@ -9721,7 +9721,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606770000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19450.86,
       (string) (len=4) "high": (float64) 19519.74,
       (string) (len=3) "low": (float64) 19395.59,
@@ -9733,7 +9733,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606771800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19382,
       (string) (len=4) "high": (float64) 19471.69,
       (string) (len=3) "low": (float64) 19346.98,
@@ -9745,7 +9745,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606773600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19386.39,
       (string) (len=4) "high": (float64) 19388.61,
       (string) (len=3) "low": (float64) 19261.84,
@@ -9757,7 +9757,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606775400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19500,
       (string) (len=4) "high": (float64) 19500,
       (string) (len=3) "low": (float64) 19380.31,
@@ -9769,7 +9769,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606777200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19624.75,
       (string) (len=4) "high": (float64) 19624.75,
       (string) (len=3) "low": (float64) 19460.42,
@@ -9781,7 +9781,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606779000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19713.94,
       (string) (len=4) "high": (float64) 19775,
       (string) (len=3) "low": (float64) 19611.92,
@@ -9793,7 +9793,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606780800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19683.3,
       (string) (len=4) "high": (float64) 19730,
       (string) (len=3) "low": (float64) 19511,
@@ -9805,7 +9805,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606782600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19573.18,
       (string) (len=4) "high": (float64) 19692.63,
       (string) (len=3) "low": (float64) 19489,
@@ -9817,7 +9817,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606784400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19502.48,
       (string) (len=4) "high": (float64) 19649,
       (string) (len=3) "low": (float64) 19481.01,
@@ -9829,7 +9829,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606786200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19603.97,
       (string) (len=4) "high": (float64) 19642.69,
       (string) (len=3) "low": (float64) 19440.17,
@@ -9841,7 +9841,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606788000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19640.81,
       (string) (len=4) "high": (float64) 19680,
       (string) (len=3) "low": (float64) 19544.15,
@@ -9853,7 +9853,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606789800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19691.22,
       (string) (len=4) "high": (float64) 19718.4,
       (string) (len=3) "low": (float64) 19591.61,
@@ -9865,7 +9865,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606791600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19574.73,
       (string) (len=4) "high": (float64) 19693.21,
       (string) (len=3) "low": (float64) 19552.36,
@@ -9877,7 +9877,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606793400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19440.51,
       (string) (len=4) "high": (float64) 19599.71,
       (string) (len=3) "low": (float64) 19355.73,
@@ -9889,7 +9889,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606795200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19445.76,
       (string) (len=4) "high": (float64) 19532.58,
       (string) (len=3) "low": (float64) 19355.07,
@@ -9901,7 +9901,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606797000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19366.73,
       (string) (len=4) "high": (float64) 19491.91,
       (string) (len=3) "low": (float64) 19360,
@@ -9913,7 +9913,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606798800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19440.86,
       (string) (len=4) "high": (float64) 19440.92,
       (string) (len=3) "low": (float64) 19304.82,
@@ -9925,7 +9925,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606800600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19490.88,
       (string) (len=4) "high": (float64) 19509.11,
       (string) (len=3) "low": (float64) 19403.98,
@@ -9937,7 +9937,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606802400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19475.01,
       (string) (len=4) "high": (float64) 19524.01,
       (string) (len=3) "low": (float64) 19445.63,
@@ -9949,7 +9949,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606804200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19347.27,
       (string) (len=4) "high": (float64) 19475.01,
       (string) (len=3) "low": (float64) 19320.57,
@@ -9961,7 +9961,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606806000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19456.96,
       (string) (len=4) "high": (float64) 19504.94,
       (string) (len=3) "low": (float64) 19310.2,
@@ -9973,7 +9973,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606807800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19524.69,
       (string) (len=4) "high": (float64) 19556.44,
       (string) (len=3) "low": (float64) 19395.63,
@@ -9985,7 +9985,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606809600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19534.36,
       (string) (len=4) "high": (float64) 19568.91,
       (string) (len=3) "low": (float64) 19490.79,
@@ -9997,7 +9997,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606811400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19479.29,
       (string) (len=4) "high": (float64) 19577.47,
       (string) (len=3) "low": (float64) 19450,
@@ -10009,7 +10009,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606813200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19462.24,
       (string) (len=4) "high": (float64) 19560.02,
       (string) (len=3) "low": (float64) 19446.71,
@@ -10021,7 +10021,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606815000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19579.37,
       (string) (len=4) "high": (float64) 19583.01,
       (string) (len=3) "low": (float64) 19440,
@@ -10033,7 +10033,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606816800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19771.91,
       (string) (len=4) "high": (float64) 19785,
       (string) (len=3) "low": (float64) 19573.66,
@@ -10045,7 +10045,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606818600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19757.83,
       (string) (len=4) "high": (float64) 19824,
       (string) (len=3) "low": (float64) 19686.69,
@@ -10057,7 +10057,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606820400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19354.91,
       (string) (len=4) "high": (float64) 19915.14,
       (string) (len=3) "low": (float64) 19002.48,
@@ -10069,7 +10069,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606822200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19450.84,
       (string) (len=4) "high": (float64) 19592.08,
       (string) (len=3) "low": (float64) 19262.09,
@@ -10081,7 +10081,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606824000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18734.19,
       (string) (len=4) "high": (float64) 19489.18,
       (string) (len=3) "low": (float64) 18631.03,
@@ -10093,7 +10093,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606825800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18577.6,
       (string) (len=4) "high": (float64) 18998.99,
       (string) (len=3) "low": (float64) 18444,
@@ -10105,7 +10105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606827600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18751.3,
       (string) (len=4) "high": (float64) 18784.99,
       (string) (len=3) "low": (float64) 18109,
@@ -10117,7 +10117,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606829400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18788.75,
       (string) (len=4) "high": (float64) 18875.65,
       (string) (len=3) "low": (float64) 18683.46,
@@ -10129,7 +10129,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606831200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18866.6,
       (string) (len=4) "high": (float64) 18974.77,
       (string) (len=3) "low": (float64) 18662.43,
@@ -10141,7 +10141,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606833000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19308.99,
       (string) (len=4) "high": (float64) 19386.73,
       (string) (len=3) "low": (float64) 18841.28,
@@ -10153,7 +10153,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606834800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19436.72,
       (string) (len=4) "high": (float64) 19500,
       (string) (len=3) "low": (float64) 19240,
@@ -10165,7 +10165,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606836600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19281.99,
       (string) (len=4) "high": (float64) 19442.84,
       (string) (len=3) "low": (float64) 19193.89,
@@ -10177,7 +10177,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606838400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18998.02,
       (string) (len=4) "high": (float64) 19346.31,
       (string) (len=3) "low": (float64) 18950,
@@ -10189,7 +10189,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606840200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19058.17,
       (string) (len=4) "high": (float64) 19181.83,
       (string) (len=3) "low": (float64) 18987.17,
@@ -10201,7 +10201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606842000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18945.8,
       (string) (len=4) "high": (float64) 19091.93,
       (string) (len=3) "low": (float64) 18626.02,
@@ -10213,7 +10213,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606843800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19057.88,
       (string) (len=4) "high": (float64) 19091.93,
       (string) (len=3) "low": (float64) 18749,
@@ -10225,7 +10225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606845600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18879.32,
       (string) (len=4) "high": (float64) 19063.53,
       (string) (len=3) "low": (float64) 18845.39,
@@ -10237,7 +10237,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606847400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18746.07,
       (string) (len=4) "high": (float64) 18994.69,
       (string) (len=3) "low": (float64) 18695.6,
@@ -10249,7 +10249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606849200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18914.86,
       (string) (len=4) "high": (float64) 18990,
       (string) (len=3) "low": (float64) 18719.83,
@@ -10261,7 +10261,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606851000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19087.7,
       (string) (len=4) "high": (float64) 19148.97,
       (string) (len=3) "low": (float64) 18914.81,
@@ -10273,7 +10273,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606852800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18992.01,
       (string) (len=4) "high": (float64) 19153.43,
       (string) (len=3) "low": (float64) 18929.27,
@@ -10285,7 +10285,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606854600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19041.96,
       (string) (len=4) "high": (float64) 19046.82,
       (string) (len=3) "low": (float64) 18855.27,
@@ -10297,7 +10297,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606856400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19175,
       (string) (len=4) "high": (float64) 19175,
       (string) (len=3) "low": (float64) 18952.88,
@@ -10309,7 +10309,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606858200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19057.46,
       (string) (len=4) "high": (float64) 19220,
       (string) (len=3) "low": (float64) 19035.13,
@@ -10321,7 +10321,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606860000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19092.25,
       (string) (len=4) "high": (float64) 19175.42,
       (string) (len=3) "low": (float64) 19045.13,
@@ -10333,7 +10333,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606861800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18912.01,
       (string) (len=4) "high": (float64) 19127.57,
       (string) (len=3) "low": (float64) 18850,
@@ -10345,7 +10345,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606863600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18745.64,
       (string) (len=4) "high": (float64) 18958.13,
       (string) (len=3) "low": (float64) 18736,
@@ -10357,7 +10357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606865400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18782.97,
       (string) (len=4) "high": (float64) 18885.29,
       (string) (len=3) "low": (float64) 18738.82,
@@ -10369,7 +10369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606867200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18779.58,
       (string) (len=4) "high": (float64) 18795.05,
       (string) (len=3) "low": (float64) 18461.17,
@@ -10381,7 +10381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606869000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18847.92,
       (string) (len=4) "high": (float64) 18890,
       (string) (len=3) "low": (float64) 18778.29,
@@ -10393,7 +10393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606870800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18793.82,
       (string) (len=4) "high": (float64) 18842.27,
       (string) (len=3) "low": (float64) 18716.94,
@@ -10405,7 +10405,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606872600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18866.41,
       (string) (len=4) "high": (float64) 18985.99,
       (string) (len=3) "low": (float64) 18777.28,
@@ -10417,7 +10417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606874400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18774.82,
       (string) (len=4) "high": (float64) 18866.97,
       (string) (len=3) "low": (float64) 18767.12,
@@ -10429,7 +10429,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606876200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18693.14,
       (string) (len=4) "high": (float64) 18799.43,
       (string) (len=3) "low": (float64) 18660.02,
@@ -10441,7 +10441,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606878000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18586.29,
       (string) (len=4) "high": (float64) 18807.27,
       (string) (len=3) "low": (float64) 18549.98,
@@ -10453,7 +10453,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606879800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18627.9,
       (string) (len=4) "high": (float64) 18697.86,
       (string) (len=3) "low": (float64) 18523.86,
@@ -10465,7 +10465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606881600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18396.28,
       (string) (len=4) "high": (float64) 18712.51,
       (string) (len=3) "low": (float64) 18335,
@@ -10477,7 +10477,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606883400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18566.71,
       (string) (len=4) "high": (float64) 18599.99,
       (string) (len=3) "low": (float64) 18350.79,
@@ -10489,7 +10489,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606885200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18500,
       (string) (len=4) "high": (float64) 18649,
       (string) (len=3) "low": (float64) 18480,
@@ -10501,7 +10501,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606887000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18666.36,
       (string) (len=4) "high": (float64) 18675.05,
       (string) (len=3) "low": (float64) 18469.3,
@@ -10513,7 +10513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606888800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18796.25,
       (string) (len=4) "high": (float64) 18822.15,
       (string) (len=3) "low": (float64) 18640.36,
@@ -10525,7 +10525,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606890600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18932.64,
       (string) (len=4) "high": (float64) 18946.96,
       (string) (len=3) "low": (float64) 18745.01,
@@ -10537,7 +10537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606892400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18867.12,
       (string) (len=4) "high": (float64) 19000,
       (string) (len=3) "low": (float64) 18830.97,
@@ -10549,7 +10549,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606894200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19130.78,
       (string) (len=4) "high": (float64) 19133.33,
       (string) (len=3) "low": (float64) 18837.19,
@@ -10561,7 +10561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606896000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19332.4,
       (string) (len=4) "high": (float64) 19340,
       (string) (len=3) "low": (float64) 19061.02,
@@ -10573,7 +10573,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606897800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19200,
       (string) (len=4) "high": (float64) 19339.99,
       (string) (len=3) "low": (float64) 19145.57,
@@ -10585,7 +10585,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606899600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19250.61,
       (string) (len=4) "high": (float64) 19315.21,
       (string) (len=3) "low": (float64) 19149.79,
@@ -10597,7 +10597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606901400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19028.71,
       (string) (len=4) "high": (float64) 19255.78,
       (string) (len=3) "low": (float64) 19018.85,
@@ -10609,7 +10609,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606903200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19106.71,
       (string) (len=4) "high": (float64) 19154.32,
       (string) (len=3) "low": (float64) 18997.81,
@@ -10621,7 +10621,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606905000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19107.57,
       (string) (len=4) "high": (float64) 19198.66,
       (string) (len=3) "low": (float64) 19082.21,
@@ -10633,7 +10633,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606906800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19137.32,
       (string) (len=4) "high": (float64) 19191.01,
       (string) (len=3) "low": (float64) 19033.35,
@@ -10645,7 +10645,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606908600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19130.28,
       (string) (len=4) "high": (float64) 19195,
       (string) (len=3) "low": (float64) 19067.06,
@@ -10657,7 +10657,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606910400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18955.09,
       (string) (len=4) "high": (float64) 19130.42,
       (string) (len=3) "low": (float64) 18852,
@@ -10669,7 +10669,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606912200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18949.03,
       (string) (len=4) "high": (float64) 18968.22,
       (string) (len=3) "low": (float64) 18800.8,
@@ -10681,7 +10681,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606914000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19212.11,
       (string) (len=4) "high": (float64) 19248.17,
       (string) (len=3) "low": (float64) 18935.7,
@@ -10693,7 +10693,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606915800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19122.33,
       (string) (len=4) "high": (float64) 19264.6,
       (string) (len=3) "low": (float64) 19115.04,
@@ -10705,7 +10705,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606917600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18984.94,
       (string) (len=4) "high": (float64) 19172.49,
       (string) (len=3) "low": (float64) 18934.04,
@@ -10717,7 +10717,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606919400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18914.17,
       (string) (len=4) "high": (float64) 19012.45,
       (string) (len=3) "low": (float64) 18850.11,
@@ -10729,7 +10729,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606921200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18846.22,
       (string) (len=4) "high": (float64) 19000,
       (string) (len=3) "low": (float64) 18745.64,
@@ -10741,7 +10741,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606923000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18900.38,
       (string) (len=4) "high": (float64) 18936.1,
       (string) (len=3) "low": (float64) 18785.78,
@@ -10753,7 +10753,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606924800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18986.21,
       (string) (len=4) "high": (float64) 19019.63,
       (string) (len=3) "low": (float64) 18780.43,
@@ -10765,7 +10765,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606926600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18867.65,
       (string) (len=4) "high": (float64) 18990.53,
       (string) (len=3) "low": (float64) 18832.38,
@@ -10777,7 +10777,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606928400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18916.69,
       (string) (len=4) "high": (float64) 18963.15,
       (string) (len=3) "low": (float64) 18820.41,
@@ -10789,7 +10789,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606930200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18991.51,
       (string) (len=4) "high": (float64) 19018.2,
       (string) (len=3) "low": (float64) 18865.71,
@@ -10801,7 +10801,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606932000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19078.42,
       (string) (len=4) "high": (float64) 19085.28,
       (string) (len=3) "low": (float64) 18955.84,
@@ -10813,7 +10813,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606933800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19024.39,
       (string) (len=4) "high": (float64) 19080.22,
       (string) (len=3) "low": (float64) 19000,
@@ -10825,7 +10825,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606935600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19019.23,
       (string) (len=4) "high": (float64) 19130.99,
       (string) (len=3) "low": (float64) 18977.78,
@@ -10837,7 +10837,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606937400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19120.42,
       (string) (len=4) "high": (float64) 19147.73,
       (string) (len=3) "low": (float64) 19006.09,
@@ -10849,7 +10849,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606939200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.79,
       (string) (len=4) "high": (float64) 19165.94,
       (string) (len=3) "low": (float64) 19057.5,
@@ -10861,7 +10861,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606941000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.41,
       (string) (len=4) "high": (float64) 19159,
       (string) (len=3) "low": (float64) 19085.19,
@@ -10873,7 +10873,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606942800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19057.93,
       (string) (len=4) "high": (float64) 19169.99,
       (string) (len=3) "low": (float64) 19051.91,
@@ -10885,7 +10885,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606944600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19155.01,
       (string) (len=4) "high": (float64) 19160,
       (string) (len=3) "low": (float64) 19058.67,
@@ -10897,7 +10897,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606946400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19172.35,
       (string) (len=4) "high": (float64) 19240,
       (string) (len=3) "low": (float64) 19149.41,
@@ -10909,7 +10909,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606948200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19126.69,
       (string) (len=4) "high": (float64) 19207.44,
       (string) (len=3) "low": (float64) 19102.38,
@@ -10921,7 +10921,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606950000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19206.02,
       (string) (len=4) "high": (float64) 19212.13,
       (string) (len=3) "low": (float64) 19102.1,
@@ -10933,7 +10933,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606951800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19225.63,
       (string) (len=4) "high": (float64) 19274.3,
       (string) (len=3) "low": (float64) 19186.15,
@@ -10945,7 +10945,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606953600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19237,
       (string) (len=4) "high": (float64) 19300,
       (string) (len=3) "low": (float64) 19207.24,
@@ -10957,7 +10957,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606955400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19193.53,
       (string) (len=4) "high": (float64) 19239.03,
       (string) (len=3) "low": (float64) 19171.6,
@@ -10969,7 +10969,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606957200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.77,
       (string) (len=4) "high": (float64) 19193.55,
       (string) (len=3) "low": (float64) 19050,
@@ -10981,7 +10981,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606959000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19031.03,
       (string) (len=4) "high": (float64) 19100,
       (string) (len=3) "low": (float64) 18954.23,
@@ -10993,7 +10993,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606960800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19032.88,
       (string) (len=4) "high": (float64) 19097.93,
       (string) (len=3) "low": (float64) 18950.78,
@@ -11005,7 +11005,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606962600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19058.75,
       (string) (len=4) "high": (float64) 19101.03,
       (string) (len=3) "low": (float64) 19000,
@@ -11017,7 +11017,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606964400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19126.52,
       (string) (len=4) "high": (float64) 19164.77,
       (string) (len=3) "low": (float64) 19029.39,
@@ -11029,7 +11029,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606966200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19099.19,
       (string) (len=4) "high": (float64) 19190,
       (string) (len=3) "low": (float64) 19099.18,
@@ -11041,7 +11041,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606968000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19064.28,
       (string) (len=4) "high": (float64) 19127.51,
       (string) (len=3) "low": (float64) 19044.21,
@@ -11053,7 +11053,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606969800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19049.17,
       (string) (len=4) "high": (float64) 19099.5,
       (string) (len=3) "low": (float64) 19030.8,
@@ -11065,7 +11065,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606971600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19115.16,
       (string) (len=4) "high": (float64) 19123.41,
       (string) (len=3) "low": (float64) 19036.63,
@@ -11077,7 +11077,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606973400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18929.44,
       (string) (len=4) "high": (float64) 19116.02,
       (string) (len=3) "low": (float64) 18885,
@@ -11089,7 +11089,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606975200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18998.34,
       (string) (len=4) "high": (float64) 19015.68,
       (string) (len=3) "low": (float64) 18892.01,
@@ -11101,7 +11101,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606977000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18974.45,
       (string) (len=4) "high": (float64) 19012.14,
       (string) (len=3) "low": (float64) 18952.02,
@@ -11113,7 +11113,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606978800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19082.94,
       (string) (len=4) "high": (float64) 19089.19,
       (string) (len=3) "low": (float64) 18927.43,
@@ -11125,7 +11125,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606980600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19208.47,
       (string) (len=4) "high": (float64) 19255.41,
       (string) (len=3) "low": (float64) 19077.06,
@@ -11137,7 +11137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606982400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19434.3,
       (string) (len=4) "high": (float64) 19466.58,
       (string) (len=3) "low": (float64) 19175.01,
@@ -11149,7 +11149,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606984200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19390.91,
       (string) (len=4) "high": (float64) 19466.19,
       (string) (len=3) "low": (float64) 19364.98,
@@ -11161,7 +11161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606986000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19197.43,
       (string) (len=4) "high": (float64) 19434.96,
       (string) (len=3) "low": (float64) 19124.4,
@@ -11173,7 +11173,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606987800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19375,
       (string) (len=4) "high": (float64) 19375,
       (string) (len=3) "low": (float64) 19165.59,
@@ -11185,7 +11185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606989600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19405.42,
       (string) (len=4) "high": (float64) 19412.93,
       (string) (len=3) "low": (float64) 19252.24,
@@ -11197,7 +11197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606991400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19364.44,
       (string) (len=4) "high": (float64) 19435.49,
       (string) (len=3) "low": (float64) 19342.3,
@@ -11209,7 +11209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606993200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19433.87,
       (string) (len=4) "high": (float64) 19460,
       (string) (len=3) "low": (float64) 19300.23,
@@ -11221,7 +11221,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606995000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19411.84,
       (string) (len=4) "high": (float64) 19444.77,
       (string) (len=3) "low": (float64) 19330.72,
@@ -11233,7 +11233,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606996800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19320.16,
       (string) (len=4) "high": (float64) 19440.09,
       (string) (len=3) "low": (float64) 19250.5,
@@ -11245,7 +11245,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606998600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19350.11,
       (string) (len=4) "high": (float64) 19359.47,
       (string) (len=3) "low": (float64) 19274.82,
@@ -11257,7 +11257,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607000400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19360.91,
       (string) (len=4) "high": (float64) 19398.19,
       (string) (len=3) "low": (float64) 19347,
@@ -11269,7 +11269,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607002200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19302.3,
       (string) (len=4) "high": (float64) 19387.86,
       (string) (len=3) "low": (float64) 19274.56,
@@ -11281,7 +11281,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607004000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19392.25,
       (string) (len=4) "high": (float64) 19429.34,
       (string) (len=3) "low": (float64) 19290.32,
@@ -11293,7 +11293,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607005800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19370.06,
       (string) (len=4) "high": (float64) 19392.78,
       (string) (len=3) "low": (float64) 19336.52,
@@ -11305,7 +11305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607007600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19410.89,
       (string) (len=4) "high": (float64) 19419.49,
       (string) (len=3) "low": (float64) 19322.27,
@@ -11317,7 +11317,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607009400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19556.13,
       (string) (len=4) "high": (float64) 19558.78,
       (string) (len=3) "low": (float64) 19385.63,
@@ -11329,7 +11329,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607011200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19393.76,
       (string) (len=4) "high": (float64) 19625.64,
       (string) (len=3) "low": (float64) 19280,
@@ -11341,7 +11341,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607013000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19380.28,
       (string) (len=4) "high": (float64) 19456.71,
       (string) (len=3) "low": (float64) 19335.01,
@@ -11353,7 +11353,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607014800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19297.62,
       (string) (len=4) "high": (float64) 19403.32,
       (string) (len=3) "low": (float64) 19210.82,
@@ -11365,7 +11365,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607016600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19317.03,
       (string) (len=4) "high": (float64) 19332.12,
       (string) (len=3) "low": (float64) 19260,
@@ -11377,7 +11377,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607018400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19389.07,
       (string) (len=4) "high": (float64) 19398.73,
       (string) (len=3) "low": (float64) 19317.01,
@@ -11389,7 +11389,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607020200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19400.25,
       (string) (len=4) "high": (float64) 19418.63,
       (string) (len=3) "low": (float64) 19355.5,
@@ -11401,7 +11401,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607022000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19365.28,
       (string) (len=4) "high": (float64) 19406.31,
       (string) (len=3) "low": (float64) 19360.61,
@@ -11413,7 +11413,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607023800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19442.2,
       (string) (len=4) "high": (float64) 19450,
       (string) (len=3) "low": (float64) 19365.05,
@@ -11425,7 +11425,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607025600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19411.46,
       (string) (len=4) "high": (float64) 19465,
       (string) (len=3) "low": (float64) 19405.22,
@@ -11437,7 +11437,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607027400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19387.59,
       (string) (len=4) "high": (float64) 19424.49,
       (string) (len=3) "low": (float64) 19320,
@@ -11449,7 +11449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607029200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19401.26,
       (string) (len=4) "high": (float64) 19417.4,
       (string) (len=3) "low": (float64) 19350,
@@ -11461,7 +11461,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607031000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19463.29,
       (string) (len=4) "high": (float64) 19475,
       (string) (len=3) "low": (float64) 19394,
@@ -11473,7 +11473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607032800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19497.05,
       (string) (len=4) "high": (float64) 19497.35,
       (string) (len=3) "low": (float64) 19452.26,
@@ -11485,7 +11485,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607034600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19489.22,
       (string) (len=4) "high": (float64) 19497.35,
       (string) (len=3) "low": (float64) 19430.33,
@@ -11497,7 +11497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607036400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19466.29,
       (string) (len=4) "high": (float64) 19556.3,
       (string) (len=3) "low": (float64) 19451.21,
@@ -11509,7 +11509,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607038200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19448.64,
       (string) (len=4) "high": (float64) 19479.27,
       (string) (len=3) "low": (float64) 19435.71,
@@ -11521,7 +11521,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607040000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19484.61,
       (string) (len=4) "high": (float64) 19493,
       (string) (len=3) "low": (float64) 19399,
@@ -11533,7 +11533,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607041800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19491.95,
       (string) (len=4) "high": (float64) 19546.46,
       (string) (len=3) "low": (float64) 19475.73,
@@ -11545,7 +11545,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607043600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19398.99,
       (string) (len=4) "high": (float64) 19512.13,
       (string) (len=3) "low": (float64) 19374.98,
@@ -11557,7 +11557,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607045400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19347,
       (string) (len=4) "high": (float64) 19412.16,
       (string) (len=3) "low": (float64) 19339.05,
@@ -11569,7 +11569,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607047200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19374.84,
       (string) (len=4) "high": (float64) 19395.49,
       (string) (len=3) "low": (float64) 19332.12,
@@ -11581,7 +11581,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607049000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19273.01,
       (string) (len=4) "high": (float64) 19375.63,
       (string) (len=3) "low": (float64) 19255.6,
@@ -11593,7 +11593,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607050800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19245.05,
       (string) (len=4) "high": (float64) 19340.99,
       (string) (len=3) "low": (float64) 19235.32,
@@ -11605,7 +11605,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607052600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19183.49,
       (string) (len=4) "high": (float64) 19294.64,
       (string) (len=3) "low": (float64) 19155,
@@ -11617,7 +11617,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607054400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19287.93,
       (string) (len=4) "high": (float64) 19289.92,
       (string) (len=3) "low": (float64) 19134.28,
@@ -11629,7 +11629,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607056200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19311.53,
       (string) (len=4) "high": (float64) 19350,
       (string) (len=3) "low": (float64) 19274.75,
@@ -11641,7 +11641,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607058000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19316.76,
       (string) (len=4) "high": (float64) 19332.04,
       (string) (len=3) "low": (float64) 19290,
@@ -11653,7 +11653,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607059800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19214.37,
       (string) (len=4) "high": (float64) 19316.86,
       (string) (len=3) "low": (float64) 19205.65,
@@ -11665,7 +11665,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607061600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19375,
       (string) (len=4) "high": (float64) 19375,
       (string) (len=3) "low": (float64) 19211.11,
@@ -11677,7 +11677,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607063400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19330.62,
       (string) (len=4) "high": (float64) 19375,
       (string) (len=3) "low": (float64) 19312.05,
@@ -11689,7 +11689,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607065200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19294.58,
       (string) (len=4) "high": (float64) 19330.62,
       (string) (len=3) "low": (float64) 19275.06,
@@ -11701,7 +11701,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607067000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19309.62,
       (string) (len=4) "high": (float64) 19348.25,
       (string) (len=3) "low": (float64) 19263.55,
@@ -11713,7 +11713,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607068800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19442.78,
       (string) (len=4) "high": (float64) 19442.78,
       (string) (len=3) "low": (float64) 19304.88,
@@ -11725,7 +11725,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607070600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19405.42,
       (string) (len=4) "high": (float64) 19464.06,
       (string) (len=3) "low": (float64) 19372.47,
@@ -11737,7 +11737,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607072400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19351.74,
       (string) (len=4) "high": (float64) 19422.54,
       (string) (len=3) "low": (float64) 19330.72,
@@ -11749,7 +11749,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607074200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19378.88,
       (string) (len=4) "high": (float64) 19397.23,
       (string) (len=3) "low": (float64) 19342.34,
@@ -11761,7 +11761,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607076000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18972.14,
       (string) (len=4) "high": (float64) 19378.88,
       (string) (len=3) "low": (float64) 18899.84,
@@ -11773,7 +11773,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607077800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19003.15,
       (string) (len=4) "high": (float64) 19078.96,
       (string) (len=3) "low": (float64) 18907.74,
@@ -11785,7 +11785,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607079600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19003.22,
       (string) (len=4) "high": (float64) 19130.91,
       (string) (len=3) "low": (float64) 18980.01,
@@ -11797,7 +11797,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607081400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18837.41,
       (string) (len=4) "high": (float64) 19079.89,
       (string) (len=3) "low": (float64) 18784.55,
@@ -11809,7 +11809,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607083200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18877.25,
       (string) (len=4) "high": (float64) 18902.15,
       (string) (len=3) "low": (float64) 18700,
@@ -11821,7 +11821,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607085000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19038.91,
       (string) (len=4) "high": (float64) 19055.69,
       (string) (len=3) "low": (float64) 18877.24,
@@ -11833,7 +11833,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607086800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18991.01,
       (string) (len=4) "high": (float64) 19046.62,
       (string) (len=3) "low": (float64) 18911.38,
@@ -11845,7 +11845,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607088600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19023.89,
       (string) (len=4) "high": (float64) 19045.34,
       (string) (len=3) "low": (float64) 18961.72,
@@ -11857,7 +11857,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607090400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19150,
       (string) (len=4) "high": (float64) 19161.63,
       (string) (len=3) "low": (float64) 18940,
@@ -11869,7 +11869,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607092200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19065.67,
       (string) (len=4) "high": (float64) 19157.87,
       (string) (len=3) "low": (float64) 19052.04,
@@ -11881,7 +11881,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607094000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18985.8,
       (string) (len=4) "high": (float64) 19092.89,
       (string) (len=3) "low": (float64) 18952.23,
@@ -11893,7 +11893,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607095800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18966.96,
       (string) (len=4) "high": (float64) 19026.79,
       (string) (len=3) "low": (float64) 18956.17,
@@ -11905,7 +11905,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607097600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18924.7,
       (string) (len=4) "high": (float64) 18997.74,
       (string) (len=3) "low": (float64) 18844,
@@ -11917,7 +11917,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607099400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18995.39,
       (string) (len=4) "high": (float64) 18998,
       (string) (len=3) "low": (float64) 18827.66,
@@ -11929,7 +11929,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607101200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18996.07,
       (string) (len=4) "high": (float64) 19037.24,
       (string) (len=3) "low": (float64) 18955.94,
@@ -11941,7 +11941,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607103000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18977.07,
       (string) (len=4) "high": (float64) 19032.16,
       (string) (len=3) "low": (float64) 18943.42,
@@ -11953,7 +11953,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607104800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18997.14,
       (string) (len=4) "high": (float64) 19004.74,
       (string) (len=3) "low": (float64) 18939.14,
@@ -11965,7 +11965,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607106600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19069.75,
       (string) (len=4) "high": (float64) 19084.76,
       (string) (len=3) "low": (float64) 18996.68,
@@ -11977,7 +11977,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607108400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19024.01,
       (string) (len=4) "high": (float64) 19078.67,
       (string) (len=3) "low": (float64) 19021.19,
@@ -11989,7 +11989,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607110200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19056.01,
       (string) (len=4) "high": (float64) 19075.29,
       (string) (len=3) "low": (float64) 19011.36,
@@ -12001,7 +12001,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607112000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19010.45,
       (string) (len=4) "high": (float64) 19059.44,
       (string) (len=3) "low": (float64) 18969.63,
@@ -12013,7 +12013,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607113800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18978.53,
       (string) (len=4) "high": (float64) 19013.72,
       (string) (len=3) "low": (float64) 18900.01,
@@ -12025,7 +12025,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607115600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18839.98,
       (string) (len=4) "high": (float64) 19005.96,
       (string) (len=3) "low": (float64) 18831.02,
@@ -12037,7 +12037,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607117400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18821.5,
       (string) (len=4) "high": (float64) 18907.61,
       (string) (len=3) "low": (float64) 18750,
@@ -12049,7 +12049,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607119200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18790.32,
       (string) (len=4) "high": (float64) 18886.1,
       (string) (len=3) "low": (float64) 18769.7,
@@ -12061,7 +12061,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607121000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18673.76,
       (string) (len=4) "high": (float64) 18845,
       (string) (len=3) "low": (float64) 18576.05,
@@ -12073,7 +12073,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607122800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18834.95,
       (string) (len=4) "high": (float64) 18852.43,
       (string) (len=3) "low": (float64) 18624.03,
@@ -12085,7 +12085,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607124600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18658.1,
       (string) (len=4) "high": (float64) 18840.52,
       (string) (len=3) "low": (float64) 18634.63,
@@ -12097,7 +12097,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607126400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18624.04,
       (string) (len=4) "high": (float64) 18696.94,
       (string) (len=3) "low": (float64) 18501,
@@ -12109,7 +12109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607128200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18785.37,
       (string) (len=4) "high": (float64) 18811.28,
       (string) (len=3) "low": (float64) 18620.34,
@@ -12121,7 +12121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607130000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18746.73,
       (string) (len=4) "high": (float64) 18832.26,
       (string) (len=3) "low": (float64) 18730.09,
@@ -12133,7 +12133,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607131800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18665.38,
       (string) (len=4) "high": (float64) 18797,
       (string) (len=3) "low": (float64) 18657.13,
@@ -12145,7 +12145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607133600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18773.41,
       (string) (len=4) "high": (float64) 18778.94,
       (string) (len=3) "low": (float64) 18658.1,
@@ -12157,7 +12157,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607135400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18815.43,
       (string) (len=4) "high": (float64) 18864.95,
       (string) (len=3) "low": (float64) 18773.4,
@@ -12169,7 +12169,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607137200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18868.89,
       (string) (len=4) "high": (float64) 18888.88,
       (string) (len=3) "low": (float64) 18763.99,
@@ -12181,7 +12181,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607139000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18831.82,
       (string) (len=4) "high": (float64) 18900,
       (string) (len=3) "low": (float64) 18821.95,
@@ -12193,7 +12193,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607140800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18924.79,
       (string) (len=4) "high": (float64) 18924.79,
       (string) (len=3) "low": (float64) 18820.15,
@@ -12205,7 +12205,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607142600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18884.92,
       (string) (len=4) "high": (float64) 18951.99,
       (string) (len=3) "low": (float64) 18861.2,
@@ -12217,7 +12217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607144400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18881.14,
       (string) (len=4) "high": (float64) 18904.36,
       (string) (len=3) "low": (float64) 18860.04,
@@ -12229,7 +12229,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607146200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18973.07,
       (string) (len=4) "high": (float64) 18985.97,
       (string) (len=3) "low": (float64) 18881.66,
@@ -12241,7 +12241,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607148000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18940.11,
       (string) (len=4) "high": (float64) 18984.28,
       (string) (len=3) "low": (float64) 18929.15,
@@ -12253,7 +12253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607149800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18983.07,
       (string) (len=4) "high": (float64) 18999,
       (string) (len=3) "low": (float64) 18926.6,
@@ -12265,7 +12265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607151600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18958.69,
       (string) (len=4) "high": (float64) 18999,
       (string) (len=3) "low": (float64) 18921,
@@ -12277,7 +12277,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607153400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18931.01,
       (string) (len=4) "high": (float64) 18998.95,
       (string) (len=3) "low": (float64) 18924.06,
@@ -12289,7 +12289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607155200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19099.99,
       (string) (len=4) "high": (float64) 19100,
       (string) (len=3) "low": (float64) 18931,
@@ -12301,7 +12301,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607157000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19168.21,
       (string) (len=4) "high": (float64) 19189.98,
       (string) (len=3) "low": (float64) 19078.91,
@@ -12313,7 +12313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607158800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19115,
       (string) (len=4) "high": (float64) 19175,
       (string) (len=3) "low": (float64) 19085.84,
@@ -12325,7 +12325,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607160600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19128.09,
       (string) (len=4) "high": (float64) 19131.63,
       (string) (len=3) "low": (float64) 19074.84,
@@ -12337,7 +12337,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607162400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19085.45,
       (string) (len=4) "high": (float64) 19149,
       (string) (len=3) "low": (float64) 19059.88,
@@ -12349,7 +12349,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607164200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19131.64,
       (string) (len=4) "high": (float64) 19140,
       (string) (len=3) "low": (float64) 19067.44,
@@ -12361,7 +12361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607166000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18992.51,
       (string) (len=4) "high": (float64) 19143.1,
       (string) (len=3) "low": (float64) 18988.84,
@@ -12373,7 +12373,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607167800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19032.92,
       (string) (len=4) "high": (float64) 19060.92,
       (string) (len=3) "low": (float64) 18982.12,
@@ -12385,7 +12385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607169600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19036.11,
       (string) (len=4) "high": (float64) 19092.08,
       (string) (len=3) "low": (float64) 18977.04,
@@ -12397,7 +12397,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607171400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19083.32,
       (string) (len=4) "high": (float64) 19091.58,
       (string) (len=3) "low": (float64) 19018.06,
@@ -12409,7 +12409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607173200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19010.71,
       (string) (len=4) "high": (float64) 19087.59,
       (string) (len=3) "low": (float64) 19001.01,
@@ -12421,7 +12421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607175000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18995.45,
       (string) (len=4) "high": (float64) 19023.11,
       (string) (len=3) "low": (float64) 18959.63,
@@ -12433,7 +12433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607176800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19015,
       (string) (len=4) "high": (float64) 19059.07,
       (string) (len=3) "low": (float64) 18977.97,
@@ -12445,7 +12445,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607178600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.17,
       (string) (len=4) "high": (float64) 19099.72,
       (string) (len=3) "low": (float64) 19000,
@@ -12457,7 +12457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607180400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19091,
       (string) (len=4) "high": (float64) 19163.45,
       (string) (len=3) "low": (float64) 19067.16,
@@ -12469,7 +12469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607182200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19126.14,
       (string) (len=4) "high": (float64) 19129,
       (string) (len=3) "low": (float64) 19062.03,
@@ -12481,7 +12481,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607184000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19079.12,
       (string) (len=4) "high": (float64) 19157.93,
       (string) (len=3) "low": (float64) 19073.51,
@@ -12493,7 +12493,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607185800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19111.17,
       (string) (len=4) "high": (float64) 19127.25,
       (string) (len=3) "low": (float64) 19066.48,
@@ -12505,7 +12505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607187600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19080.56,
       (string) (len=4) "high": (float64) 19118,
       (string) (len=3) "low": (float64) 19042,
@@ -12517,7 +12517,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607189400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19139.41,
       (string) (len=4) "high": (float64) 19139.69,
       (string) (len=3) "low": (float64) 19073.86,
@@ -12529,7 +12529,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607191200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19137.13,
       (string) (len=4) "high": (float64) 19150,
       (string) (len=3) "low": (float64) 19106.58,
@@ -12541,7 +12541,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607193000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19130.9,
       (string) (len=4) "high": (float64) 19158,
       (string) (len=3) "low": (float64) 19106.98,
@@ -12553,7 +12553,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607194800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19106.41,
       (string) (len=4) "high": (float64) 19185.83,
       (string) (len=3) "low": (float64) 19104.36,
@@ -12565,7 +12565,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607196600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19137,
       (string) (len=4) "high": (float64) 19137.03,
       (string) (len=3) "low": (float64) 19089.99,
@@ -12577,7 +12577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607198400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19104.94,
       (string) (len=4) "high": (float64) 19155.61,
       (string) (len=3) "low": (float64) 19086.34,
@@ -12589,7 +12589,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607200200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19066.66,
       (string) (len=4) "high": (float64) 19136.6,
       (string) (len=3) "low": (float64) 19025.01,
@@ -12601,7 +12601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607202000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19072.85,
       (string) (len=4) "high": (float64) 19127.04,
       (string) (len=3) "low": (float64) 19065.29,
@@ -12613,7 +12613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607203800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19018.74,
       (string) (len=4) "high": (float64) 19075,
       (string) (len=3) "low": (float64) 19011.91,
@@ -12625,7 +12625,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607205600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19045.53,
       (string) (len=4) "high": (float64) 19060.92,
       (string) (len=3) "low": (float64) 19003.47,
@@ -12637,7 +12637,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607207400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19028.68,
       (string) (len=4) "high": (float64) 19067.22,
       (string) (len=3) "low": (float64) 19010,
@@ -12649,7 +12649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607209200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19085.68,
       (string) (len=4) "high": (float64) 19089.34,
       (string) (len=3) "low": (float64) 19028.67,
@@ -12661,7 +12661,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607211000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19158.96,
       (string) (len=4) "high": (float64) 19168.52,
       (string) (len=3) "low": (float64) 19065.58,
@@ -12673,7 +12673,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607212800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19188.44,
       (string) (len=4) "high": (float64) 19275,
       (string) (len=3) "low": (float64) 19150,
@@ -12685,7 +12685,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607214600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19282.34,
       (string) (len=4) "high": (float64) 19297.02,
       (string) (len=3) "low": (float64) 19180.35,
@@ -12697,7 +12697,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607216400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19309.56,
       (string) (len=4) "high": (float64) 19349,
       (string) (len=3) "low": (float64) 19240.78,
@@ -12709,7 +12709,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607218200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19267.99,
       (string) (len=4) "high": (float64) 19339.38,
       (string) (len=3) "low": (float64) 19234.99,
@@ -12721,7 +12721,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607220000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19279.01,
       (string) (len=4) "high": (float64) 19293.02,
       (string) (len=3) "low": (float64) 19210.28,
@@ -12733,7 +12733,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607221800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19239.61,
       (string) (len=4) "high": (float64) 19287.93,
       (string) (len=3) "low": (float64) 19235.76,
@@ -12745,7 +12745,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607223600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19200,
       (string) (len=4) "high": (float64) 19255.79,
       (string) (len=3) "low": (float64) 19158.34,
@@ -12757,7 +12757,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607225400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19199.16,
       (string) (len=4) "high": (float64) 19207.1,
       (string) (len=3) "low": (float64) 19150,
@@ -12769,7 +12769,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607227200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19208.3,
       (string) (len=4) "high": (float64) 19241.93,
       (string) (len=3) "low": (float64) 19169.59,
@@ -12781,7 +12781,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607229000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19198.43,
       (string) (len=4) "high": (float64) 19238.73,
       (string) (len=3) "low": (float64) 19193.81,
@@ -12793,7 +12793,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607230800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19134.83,
       (string) (len=4) "high": (float64) 19229.51,
       (string) (len=3) "low": (float64) 19113.14,
@@ -12805,7 +12805,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607232600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19164.97,
       (string) (len=4) "high": (float64) 19192.75,
       (string) (len=3) "low": (float64) 19121.61,
@@ -12817,7 +12817,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607234400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19206.98,
       (string) (len=4) "high": (float64) 19220,
       (string) (len=3) "low": (float64) 19150,
@@ -12829,7 +12829,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607236200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19196.66,
       (string) (len=4) "high": (float64) 19237.69,
       (string) (len=3) "low": (float64) 19192.47,
@@ -12841,7 +12841,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607238000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19252.16,
       (string) (len=4) "high": (float64) 19262.06,
       (string) (len=3) "low": (float64) 19186.84,
@@ -12853,7 +12853,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607239800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19243.42,
       (string) (len=4) "high": (float64) 19271.99,
       (string) (len=3) "low": (float64) 19216.38,
@@ -12865,7 +12865,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607241600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19165.65,
       (string) (len=4) "high": (float64) 19264.53,
       (string) (len=3) "low": (float64) 19134.65,
@@ -12877,7 +12877,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607243400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19033.57,
       (string) (len=4) "high": (float64) 19162.22,
       (string) (len=3) "low": (float64) 19019.61,
@@ -12889,7 +12889,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607245200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19064.41,
       (string) (len=4) "high": (float64) 19094.86,
       (string) (len=3) "low": (float64) 19015.01,
@@ -12901,7 +12901,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607247000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19058.34,
       (string) (len=4) "high": (float64) 19094.37,
       (string) (len=3) "low": (float64) 18968.37,
@@ -12913,7 +12913,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607248800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19035.91,
       (string) (len=4) "high": (float64) 19074.43,
       (string) (len=3) "low": (float64) 18972.19,
@@ -12925,7 +12925,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607250600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19053.87,
       (string) (len=4) "high": (float64) 19070.12,
       (string) (len=3) "low": (float64) 19003.55,
@@ -12937,7 +12937,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607252400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18984.49,
       (string) (len=4) "high": (float64) 19061.85,
       (string) (len=3) "low": (float64) 18976.83,
@@ -12949,7 +12949,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607254200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19100,
       (string) (len=4) "high": (float64) 19108.2,
       (string) (len=3) "low": (float64) 18984.5,
@@ -12961,7 +12961,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607256000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19073.49,
       (string) (len=4) "high": (float64) 19099.99,
       (string) (len=3) "low": (float64) 19047.79,
@@ -12973,7 +12973,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607257800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18993.79,
       (string) (len=4) "high": (float64) 19073.52,
       (string) (len=3) "low": (float64) 18975,
@@ -12985,7 +12985,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607259600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19030.98,
       (string) (len=4) "high": (float64) 19031.88,
       (string) (len=3) "low": (float64) 18984.16,
@@ -12997,7 +12997,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607261400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18968.6,
       (string) (len=4) "high": (float64) 19036.61,
       (string) (len=3) "low": (float64) 18878,
@@ -13009,7 +13009,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607263200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.01,
       (string) (len=4) "high": (float64) 19111.87,
       (string) (len=3) "low": (float64) 18950.64,
@@ -13021,7 +13021,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607265000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19132.08,
       (string) (len=4) "high": (float64) 19148.48,
       (string) (len=3) "low": (float64) 19057.51,
@@ -13033,7 +13033,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607266800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19139.31,
       (string) (len=4) "high": (float64) 19172.97,
       (string) (len=3) "low": (float64) 19110.19,
@@ -13045,7 +13045,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607268600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19145.45,
       (string) (len=4) "high": (float64) 19150.86,
       (string) (len=3) "low": (float64) 19112.58,
@@ -13057,7 +13057,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607270400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19063.25,
       (string) (len=4) "high": (float64) 19219.99,
       (string) (len=3) "low": (float64) 19024.16,
@@ -13069,7 +13069,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607272200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19122.25,
       (string) (len=4) "high": (float64) 19128.29,
       (string) (len=3) "low": (float64) 19042.87,
@@ -13081,7 +13081,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607274000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19169.78,
       (string) (len=4) "high": (float64) 19194.9,
       (string) (len=3) "low": (float64) 19082.51,
@@ -13093,7 +13093,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607275800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19145.83,
       (string) (len=4) "high": (float64) 19179.05,
       (string) (len=3) "low": (float64) 19133.68,
@@ -13105,7 +13105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607277600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19126.48,
       (string) (len=4) "high": (float64) 19180,
       (string) (len=3) "low": (float64) 19108.02,
@@ -13117,7 +13117,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607279400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19116.65,
       (string) (len=4) "high": (float64) 19147.55,
       (string) (len=3) "low": (float64) 19100,
@@ -13129,7 +13129,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607281200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19090.82,
       (string) (len=4) "high": (float64) 19168.02,
       (string) (len=3) "low": (float64) 19086.63,
@@ -13141,7 +13141,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607283000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19148.17,
       (string) (len=4) "high": (float64) 19156.6,
       (string) (len=3) "low": (float64) 19090,
@@ -13153,7 +13153,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607284800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19157.57,
       (string) (len=4) "high": (float64) 19171.63,
       (string) (len=3) "low": (float64) 19145,
@@ -13165,7 +13165,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607286600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19177.35,
       (string) (len=4) "high": (float64) 19195.17,
       (string) (len=3) "low": (float64) 19150.74,
@@ -13177,7 +13177,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607288400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19164.43,
       (string) (len=4) "high": (float64) 19180.96,
       (string) (len=3) "low": (float64) 19136.46,
@@ -13189,7 +13189,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607290200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19247.64,
       (string) (len=4) "high": (float64) 19247.64,
       (string) (len=3) "low": (float64) 19164.43,
@@ -13201,7 +13201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607292000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19180.69,
       (string) (len=4) "high": (float64) 19255,
       (string) (len=3) "low": (float64) 19175,
@@ -13213,7 +13213,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607293800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19142.47,
       (string) (len=4) "high": (float64) 19181.45,
       (string) (len=3) "low": (float64) 19062,
@@ -13225,7 +13225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607295600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19361.07,
       (string) (len=4) "high": (float64) 19430.25,
       (string) (len=3) "low": (float64) 19139.75,
@@ -13237,7 +13237,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607297400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19375.6,
       (string) (len=4) "high": (float64) 19395,
       (string) (len=3) "low": (float64) 19305.41,
@@ -13249,7 +13249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607299200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19362.4,
       (string) (len=4) "high": (float64) 19432.57,
       (string) (len=3) "low": (float64) 19326.45,
@@ -13261,7 +13261,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607301000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19327.29,
       (string) (len=4) "high": (float64) 19410,
       (string) (len=3) "low": (float64) 19300,
@@ -13273,7 +13273,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607302800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19284.37,
       (string) (len=4) "high": (float64) 19357.6,
       (string) (len=3) "low": (float64) 19271.42,
@@ -13285,7 +13285,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607304600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19304.23,
       (string) (len=4) "high": (float64) 19315.37,
       (string) (len=3) "low": (float64) 19230.17,
@@ -13297,7 +13297,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607306400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19217.39,
       (string) (len=4) "high": (float64) 19314.32,
       (string) (len=3) "low": (float64) 19185.24,
@@ -13309,7 +13309,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607308200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19215.63,
       (string) (len=4) "high": (float64) 19266.98,
       (string) (len=3) "low": (float64) 19210.01,
@@ -13321,7 +13321,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607310000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19241.38,
       (string) (len=4) "high": (float64) 19261.72,
       (string) (len=3) "low": (float64) 19172.99,
@@ -13333,7 +13333,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607311800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19294.77,
       (string) (len=4) "high": (float64) 19294.77,
       (string) (len=3) "low": (float64) 19202.9,
@@ -13345,7 +13345,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607313600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19259.17,
       (string) (len=4) "high": (float64) 19294.77,
       (string) (len=3) "low": (float64) 19255.96,
@@ -13357,7 +13357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607315400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19294.22,
       (string) (len=4) "high": (float64) 19317.47,
       (string) (len=3) "low": (float64) 19245.98,
@@ -13369,7 +13369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607317200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19306,
       (string) (len=4) "high": (float64) 19306,
       (string) (len=3) "low": (float64) 19255.33,
@@ -13381,7 +13381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607319000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19247.86,
       (string) (len=4) "high": (float64) 19306,
       (string) (len=3) "low": (float64) 19246.19,
@@ -13393,7 +13393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607320800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19338.82,
       (string) (len=4) "high": (float64) 19359.99,
       (string) (len=3) "low": (float64) 19243.87,
@@ -13405,7 +13405,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607322600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19308.23,
       (string) (len=4) "high": (float64) 19338.83,
       (string) (len=3) "low": (float64) 19296.92,
@@ -13417,7 +13417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607324400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19334.33,
       (string) (len=4) "high": (float64) 19366.84,
       (string) (len=3) "low": (float64) 19308.23,
@@ -13429,7 +13429,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607326200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19378.35,
       (string) (len=4) "high": (float64) 19399,
       (string) (len=3) "low": (float64) 19302.31,
@@ -13441,7 +13441,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607328000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19263.11,
       (string) (len=4) "high": (float64) 19390.32,
       (string) (len=3) "low": (float64) 19257.48,
@@ -13453,7 +13453,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607329800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19258.28,
       (string) (len=4) "high": (float64) 19265.04,
       (string) (len=3) "low": (float64) 19211.77,
@@ -13465,7 +13465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607331600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19187.99,
       (string) (len=4) "high": (float64) 19261.39,
       (string) (len=3) "low": (float64) 19183.76,
@@ -13477,7 +13477,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607333400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19217.79,
       (string) (len=4) "high": (float64) 19243.91,
       (string) (len=3) "low": (float64) 19182.36,
@@ -13489,7 +13489,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607335200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19238.98,
       (string) (len=4) "high": (float64) 19256.89,
       (string) (len=3) "low": (float64) 19177,
@@ -13501,7 +13501,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607337000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19197.01,
       (string) (len=4) "high": (float64) 19244.33,
       (string) (len=3) "low": (float64) 19185,
@@ -13513,7 +13513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607338800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19203.34,
       (string) (len=4) "high": (float64) 19235.23,
       (string) (len=3) "low": (float64) 19176,
@@ -13525,7 +13525,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607340600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19112.66,
       (string) (len=4) "high": (float64) 19210.62,
       (string) (len=3) "low": (float64) 19100,
@@ -13537,7 +13537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607342400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19200.77,
       (string) (len=4) "high": (float64) 19209.94,
       (string) (len=3) "low": (float64) 19100,
@@ -13549,7 +13549,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607344200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19238.84,
       (string) (len=4) "high": (float64) 19247.74,
       (string) (len=3) "low": (float64) 19188.43,
@@ -13561,7 +13561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607346000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19194.71,
       (string) (len=4) "high": (float64) 19263.21,
       (string) (len=3) "low": (float64) 19191.47,
@@ -13573,7 +13573,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607347800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19196.39,
       (string) (len=4) "high": (float64) 19236.82,
       (string) (len=3) "low": (float64) 19194.7,
@@ -13585,7 +13585,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607349600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19218.43,
       (string) (len=4) "high": (float64) 19237.37,
       (string) (len=3) "low": (float64) 19107.23,
@@ -13597,7 +13597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607351400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19210.58,
       (string) (len=4) "high": (float64) 19231.21,
       (string) (len=3) "low": (float64) 19115.83,
@@ -13609,7 +13609,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607353200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19252.96,
       (string) (len=4) "high": (float64) 19270.22,
       (string) (len=3) "low": (float64) 19182.24,
@@ -13621,7 +13621,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607355000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19227.81,
       (string) (len=4) "high": (float64) 19265.46,
       (string) (len=3) "low": (float64) 19213.89,
@@ -13633,7 +13633,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607356800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19253.49,
       (string) (len=4) "high": (float64) 19254.01,
       (string) (len=3) "low": (float64) 19185.11,
@@ -13645,7 +13645,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607358600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19198.16,
       (string) (len=4) "high": (float64) 19251.67,
       (string) (len=3) "low": (float64) 19185.28,
@@ -13657,7 +13657,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607360400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19188.79,
       (string) (len=4) "high": (float64) 19219.12,
       (string) (len=3) "low": (float64) 19169.38,
@@ -13669,7 +13669,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607362200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19171.47,
       (string) (len=4) "high": (float64) 19189.11,
       (string) (len=3) "low": (float64) 19145.7,
@@ -13681,7 +13681,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607364000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19005,
       (string) (len=4) "high": (float64) 19195.14,
       (string) (len=3) "low": (float64) 18938.31,
@@ -13693,7 +13693,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607365800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18943.95,
       (string) (len=4) "high": (float64) 19027.62,
       (string) (len=3) "low": (float64) 18901,
@@ -13705,7 +13705,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607367600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19019.72,
       (string) (len=4) "high": (float64) 19021.41,
       (string) (len=3) "low": (float64) 18911.12,
@@ -13717,7 +13717,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607369400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18974.94,
       (string) (len=4) "high": (float64) 19046.92,
       (string) (len=3) "low": (float64) 18921.87,
@@ -13729,7 +13729,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607371200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19024.44,
       (string) (len=4) "high": (float64) 19034.45,
       (string) (len=3) "low": (float64) 18938.71,
@@ -13741,7 +13741,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607373000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19056.53,
       (string) (len=4) "high": (float64) 19063.43,
       (string) (len=3) "low": (float64) 19001.63,
@@ -13753,7 +13753,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607374800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19125.34,
       (string) (len=4) "high": (float64) 19126,
       (string) (len=3) "low": (float64) 19020.99,
@@ -13765,7 +13765,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607376600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19079.42,
       (string) (len=4) "high": (float64) 19125.63,
       (string) (len=3) "low": (float64) 19071.68,
@@ -13777,7 +13777,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607378400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19078.28,
       (string) (len=4) "high": (float64) 19119.56,
       (string) (len=3) "low": (float64) 19078.27,
@@ -13789,7 +13789,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607380200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19123.87,
       (string) (len=4) "high": (float64) 19125,
       (string) (len=3) "low": (float64) 19075.77,
@@ -13801,7 +13801,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607382000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19179.39,
       (string) (len=4) "high": (float64) 19191.96,
       (string) (len=3) "low": (float64) 19082.54,
@@ -13813,7 +13813,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607383800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19177.71,
       (string) (len=4) "high": (float64) 19229.08,
       (string) (len=3) "low": (float64) 19173.42,
@@ -13825,7 +13825,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607385600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19173.88,
       (string) (len=4) "high": (float64) 19203.39,
       (string) (len=3) "low": (float64) 19142.89,
@@ -13837,7 +13837,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607387400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19238.31,
       (string) (len=4) "high": (float64) 19242.43,
       (string) (len=3) "low": (float64) 19173.57,
@@ -13849,7 +13849,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607389200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19208.38,
       (string) (len=4) "high": (float64) 19245,
       (string) (len=3) "low": (float64) 19175,
@@ -13861,7 +13861,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607391000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19223.55,
       (string) (len=4) "high": (float64) 19229.26,
       (string) (len=3) "low": (float64) 19164.25,
@@ -13873,7 +13873,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607392800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19184.88,
       (string) (len=4) "high": (float64) 19225,
       (string) (len=3) "low": (float64) 19177.2,
@@ -13885,7 +13885,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607394600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19189.9,
       (string) (len=4) "high": (float64) 19200,
       (string) (len=3) "low": (float64) 19168.87,
@@ -13897,7 +13897,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607396400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19150.56,
       (string) (len=4) "high": (float64) 19201.59,
       (string) (len=3) "low": (float64) 19147.38,
@@ -13909,7 +13909,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607398200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19159.23,
       (string) (len=4) "high": (float64) 19188.55,
       (string) (len=3) "low": (float64) 19150.56,
@@ -13921,7 +13921,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607400000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19205.79,
       (string) (len=4) "high": (float64) 19221.73,
       (string) (len=3) "low": (float64) 19159.23,
@@ -13933,7 +13933,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607401800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19185.26,
       (string) (len=4) "high": (float64) 19212.77,
       (string) (len=3) "low": (float64) 19178.19,
@@ -13945,7 +13945,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607403600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19213.13,
       (string) (len=4) "high": (float64) 19215,
       (string) (len=3) "low": (float64) 19185.25,
@@ -13957,7 +13957,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607405400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19299.4,
       (string) (len=4) "high": (float64) 19299.41,
       (string) (len=3) "low": (float64) 19195.36,
@@ -13969,7 +13969,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607407200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19162.22,
       (string) (len=4) "high": (float64) 19299.51,
       (string) (len=3) "low": (float64) 19102.64,
@@ -13981,7 +13981,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607409000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19162.22,
       (string) (len=4) "high": (float64) 19189.92,
       (string) (len=3) "low": (float64) 19160,
@@ -13993,7 +13993,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607410800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19167.96,
       (string) (len=4) "high": (float64) 19195.5,
       (string) (len=3) "low": (float64) 19141.66,
@@ -14005,7 +14005,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607412600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19143.22,
       (string) (len=4) "high": (float64) 19186.49,
       (string) (len=3) "low": (float64) 19136.66,
@@ -14017,7 +14017,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607414400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19136.21,
       (string) (len=4) "high": (float64) 19169.13,
       (string) (len=3) "low": (float64) 19097.17,
@@ -14029,7 +14029,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607416200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19067.48,
       (string) (len=4) "high": (float64) 19138.62,
       (string) (len=3) "low": (float64) 19019.2,
@@ -14041,7 +14041,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607418000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19040.98,
       (string) (len=4) "high": (float64) 19104.09,
       (string) (len=3) "low": (float64) 19033.2,
@@ -14053,7 +14053,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607419800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18798.24,
       (string) (len=4) "high": (float64) 19046.32,
       (string) (len=3) "low": (float64) 18680.24,
@@ -14065,7 +14065,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607421600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18849,
       (string) (len=4) "high": (float64) 18887.89,
       (string) (len=3) "low": (float64) 18711.52,
@@ -14077,7 +14077,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607423400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18815.62,
       (string) (len=4) "high": (float64) 18857.89,
       (string) (len=3) "low": (float64) 18762.81,
@@ -14089,7 +14089,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607425200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18793.68,
       (string) (len=4) "high": (float64) 18875.25,
       (string) (len=3) "low": (float64) 18723.76,
@@ -14101,7 +14101,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607427000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18770,
       (string) (len=4) "high": (float64) 18837.8,
       (string) (len=3) "low": (float64) 18770,
@@ -14113,7 +14113,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607428800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18765.42,
       (string) (len=4) "high": (float64) 18864.93,
       (string) (len=3) "low": (float64) 18710.01,
@@ -14125,7 +14125,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607430600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18732.2,
       (string) (len=4) "high": (float64) 18770.33,
       (string) (len=3) "low": (float64) 18615,
@@ -14137,7 +14137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607432400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18885.25,
       (string) (len=4) "high": (float64) 18934.05,
       (string) (len=3) "low": (float64) 18732.2,
@@ -14149,7 +14149,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607434200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18929.99,
       (string) (len=4) "high": (float64) 18958.1,
       (string) (len=3) "low": (float64) 18850.95,
@@ -14161,7 +14161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607436000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18939.71,
       (string) (len=4) "high": (float64) 18984.06,
       (string) (len=3) "low": (float64) 18897.69,
@@ -14173,7 +14173,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607437800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18870.01,
       (string) (len=4) "high": (float64) 18961.73,
       (string) (len=3) "low": (float64) 18870,
@@ -14185,7 +14185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607439600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18833.82,
       (string) (len=4) "high": (float64) 18917.4,
       (string) (len=3) "low": (float64) 18807.78,
@@ -14197,7 +14197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607441400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18807.2,
       (string) (len=4) "high": (float64) 18874.48,
       (string) (len=3) "low": (float64) 18781.7,
@@ -14209,7 +14209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607443200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18891.41,
       (string) (len=4) "high": (float64) 18900,
       (string) (len=3) "low": (float64) 18752.97,
@@ -14221,7 +14221,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607445000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18834.45,
       (string) (len=4) "high": (float64) 18912.41,
       (string) (len=3) "low": (float64) 18832.23,
@@ -14233,7 +14233,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607446800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18884.56,
       (string) (len=4) "high": (float64) 18895,
       (string) (len=3) "low": (float64) 18821.69,
@@ -14245,7 +14245,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607448600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18925.42,
       (string) (len=4) "high": (float64) 18937.57,
       (string) (len=3) "low": (float64) 18853.47,
@@ -14257,7 +14257,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607450400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18890.36,
       (string) (len=4) "high": (float64) 18925.42,
       (string) (len=3) "low": (float64) 18875.37,
@@ -14269,7 +14269,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607452200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18820.42,
       (string) (len=4) "high": (float64) 18890.36,
       (string) (len=3) "low": (float64) 18818.37,
@@ -14281,7 +14281,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607454000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18865.97,
       (string) (len=4) "high": (float64) 18889.03,
       (string) (len=3) "low": (float64) 18806.9,
@@ -14293,7 +14293,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607455800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18786.88,
       (string) (len=4) "high": (float64) 18867.99,
       (string) (len=3) "low": (float64) 18781.21,
@@ -14305,7 +14305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607457600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18742.59,
       (string) (len=4) "high": (float64) 18838.76,
       (string) (len=3) "low": (float64) 18710.95,
@@ -14317,7 +14317,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607459400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18732.16,
       (string) (len=4) "high": (float64) 18784.1,
       (string) (len=3) "low": (float64) 18669.52,
@@ -14329,7 +14329,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607461200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18761.79,
       (string) (len=4) "high": (float64) 18818.76,
       (string) (len=3) "low": (float64) 18690,
@@ -14341,7 +14341,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607463000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18771.75,
       (string) (len=4) "high": (float64) 18794.08,
       (string) (len=3) "low": (float64) 18685,
@@ -14353,7 +14353,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607464800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18699.81,
       (string) (len=4) "high": (float64) 18838.51,
       (string) (len=3) "low": (float64) 18695.57,
@@ -14365,7 +14365,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607466600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18340.01,
       (string) (len=4) "high": (float64) 18710.98,
       (string) (len=3) "low": (float64) 18333.33,
@@ -14377,7 +14377,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607468400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18289.52,
       (string) (len=4) "high": (float64) 18431,
       (string) (len=3) "low": (float64) 18200,
@@ -14389,7 +14389,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607470200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18316.22,
       (string) (len=4) "high": (float64) 18398.49,
       (string) (len=3) "low": (float64) 18273.5,
@@ -14401,7 +14401,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607472000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18364.23,
       (string) (len=4) "high": (float64) 18368.49,
       (string) (len=3) "low": (float64) 18138,
@@ -14413,7 +14413,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607473800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18165,
       (string) (len=4) "high": (float64) 18368.77,
       (string) (len=3) "low": (float64) 18165,
@@ -14425,7 +14425,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607475600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18240.31,
       (string) (len=4) "high": (float64) 18275.14,
       (string) (len=3) "low": (float64) 18005.01,
@@ -14437,7 +14437,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607477400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18208.34,
       (string) (len=4) "high": (float64) 18311.09,
       (string) (len=3) "low": (float64) 18194.41,
@@ -14449,7 +14449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607479200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18261.5,
       (string) (len=4) "high": (float64) 18283.63,
       (string) (len=3) "low": (float64) 18141.44,
@@ -14461,7 +14461,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607481000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18278.13,
       (string) (len=4) "high": (float64) 18322.93,
       (string) (len=3) "low": (float64) 18200,
@@ -14473,7 +14473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607482800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18240,
       (string) (len=4) "high": (float64) 18307.98,
       (string) (len=3) "low": (float64) 18223.07,
@@ -14485,7 +14485,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607484600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18294.55,
       (string) (len=4) "high": (float64) 18297.38,
       (string) (len=3) "low": (float64) 18223.62,
@@ -14497,7 +14497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607486400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18217.74,
       (string) (len=4) "high": (float64) 18297.41,
       (string) (len=3) "low": (float64) 18198.98,
@@ -14509,7 +14509,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607488200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18155.68,
       (string) (len=4) "high": (float64) 18254.44,
       (string) (len=3) "low": (float64) 18120.52,
@@ -14521,7 +14521,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607490000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18103.54,
       (string) (len=4) "high": (float64) 18196.3,
       (string) (len=3) "low": (float64) 18081.69,
@@ -14533,7 +14533,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607491800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18206.88,
       (string) (len=4) "high": (float64) 18242.51,
       (string) (len=3) "low": (float64) 18054.13,
@@ -14545,7 +14545,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607493600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18222.88,
       (string) (len=4) "high": (float64) 18270,
       (string) (len=3) "low": (float64) 18191.91,
@@ -14557,7 +14557,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607495400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18210.94,
       (string) (len=4) "high": (float64) 18249.99,
       (string) (len=3) "low": (float64) 18154.63,
@@ -14569,7 +14569,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607497200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18123,
       (string) (len=4) "high": (float64) 18241.51,
       (string) (len=3) "low": (float64) 18112.23,
@@ -14581,7 +14581,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607499000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17925.2,
       (string) (len=4) "high": (float64) 18162.76,
       (string) (len=3) "low": (float64) 17861.68,
@@ -14593,7 +14593,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607500800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17750,
       (string) (len=4) "high": (float64) 18048.65,
       (string) (len=3) "low": (float64) 17750,
@@ -14605,7 +14605,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607502600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17949.84,
       (string) (len=4) "high": (float64) 17962.79,
       (string) (len=3) "low": (float64) 17639,
@@ -14617,7 +14617,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607504400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18083.58,
       (string) (len=4) "high": (float64) 18095.53,
       (string) (len=3) "low": (float64) 17922.68,
@@ -14629,7 +14629,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607506200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18035.33,
       (string) (len=4) "high": (float64) 18088.28,
       (string) (len=3) "low": (float64) 17905.56,
@@ -14641,7 +14641,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607508000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18097.62,
       (string) (len=4) "high": (float64) 18135.89,
       (string) (len=3) "low": (float64) 17967.08,
@@ -14653,7 +14653,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607509800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18225.19,
       (string) (len=4) "high": (float64) 18241.92,
       (string) (len=3) "low": (float64) 18088.27,
@@ -14665,7 +14665,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607511600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18297.38,
       (string) (len=4) "high": (float64) 18398.54,
       (string) (len=3) "low": (float64) 18183.7,
@@ -14677,7 +14677,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607513400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18253.93,
       (string) (len=4) "high": (float64) 18322.26,
       (string) (len=3) "low": (float64) 18241.04,
@@ -14689,7 +14689,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607515200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18290.09,
       (string) (len=4) "high": (float64) 18377.11,
       (string) (len=3) "low": (float64) 18251.16,
@@ -14701,7 +14701,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607517000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18237.44,
       (string) (len=4) "high": (float64) 18320.82,
       (string) (len=3) "low": (float64) 18219.83,
@@ -14713,7 +14713,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607518800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18204.1,
       (string) (len=4) "high": (float64) 18286.65,
       (string) (len=3) "low": (float64) 18176.66,
@@ -14725,7 +14725,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607520600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18492,
       (string) (len=4) "high": (float64) 18492,
       (string) (len=3) "low": (float64) 18186.11,
@@ -14737,7 +14737,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607522400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18462.78,
       (string) (len=4) "high": (float64) 18529.93,
       (string) (len=3) "low": (float64) 18439.47,
@@ -14749,7 +14749,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607524200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18465.14,
       (string) (len=4) "high": (float64) 18524.79,
       (string) (len=3) "low": (float64) 18444.04,
@@ -14761,7 +14761,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607526000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18338.54,
       (string) (len=4) "high": (float64) 18474.13,
       (string) (len=3) "low": (float64) 18311.45,
@@ -14773,7 +14773,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607527800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18345.9,
       (string) (len=4) "high": (float64) 18365.62,
       (string) (len=3) "low": (float64) 18288.61,
@@ -14785,7 +14785,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607529600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18320.01,
       (string) (len=4) "high": (float64) 18353.58,
       (string) (len=3) "low": (float64) 18256.12,
@@ -14797,7 +14797,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607531400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18387.92,
       (string) (len=4) "high": (float64) 18393.31,
       (string) (len=3) "low": (float64) 18285.98,
@@ -14809,7 +14809,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607533200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18330.59,
       (string) (len=4) "high": (float64) 18438.47,
       (string) (len=3) "low": (float64) 18310,
@@ -14821,7 +14821,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607535000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18297.55,
       (string) (len=4) "high": (float64) 18362.82,
       (string) (len=3) "low": (float64) 18287.72,
@@ -14833,7 +14833,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607536800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18243.65,
       (string) (len=4) "high": (float64) 18346.01,
       (string) (len=3) "low": (float64) 18230,
@@ -14845,7 +14845,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607538600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18188.51,
       (string) (len=4) "high": (float64) 18252.61,
       (string) (len=3) "low": (float64) 18154.61,
@@ -14857,7 +14857,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607540400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18240.87,
       (string) (len=4) "high": (float64) 18266.86,
       (string) (len=3) "low": (float64) 18188.51,
@@ -14869,7 +14869,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607542200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18255.14,
       (string) (len=4) "high": (float64) 18275,
       (string) (len=3) "low": (float64) 18213.3,
@@ -14881,7 +14881,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607544000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18258.35,
       (string) (len=4) "high": (float64) 18346.4,
       (string) (len=3) "low": (float64) 18246.02,
@@ -14893,7 +14893,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607545800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18323.67,
       (string) (len=4) "high": (float64) 18361.08,
       (string) (len=3) "low": (float64) 18204.75,
@@ -14905,7 +14905,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607547600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18435.71,
       (string) (len=4) "high": (float64) 18479.82,
       (string) (len=3) "low": (float64) 18311.1,
@@ -14917,7 +14917,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607549400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18517.51,
       (string) (len=4) "high": (float64) 18540,
       (string) (len=3) "low": (float64) 18427.72,
@@ -14929,7 +14929,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607551200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18538.72,
       (string) (len=4) "high": (float64) 18612.47,
       (string) (len=3) "low": (float64) 18508.28,
@@ -14941,7 +14941,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607553000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18557.47,
       (string) (len=4) "high": (float64) 18581.66,
       (string) (len=3) "low": (float64) 18500.35,
@@ -14953,7 +14953,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607554800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18599.44,
       (string) (len=4) "high": (float64) 18647.33,
       (string) (len=3) "low": (float64) 18533.65,
@@ -14965,7 +14965,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607556600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18546.55,
       (string) (len=4) "high": (float64) 18614.73,
       (string) (len=3) "low": (float64) 18540.12,
@@ -14977,7 +14977,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607558400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18458.77,
       (string) (len=4) "high": (float64) 18556.42,
       (string) (len=3) "low": (float64) 18456.12,
@@ -14989,7 +14989,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607560200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18434,
       (string) (len=4) "high": (float64) 18479.56,
       (string) (len=3) "low": (float64) 18422.03,
@@ -15001,7 +15001,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607562000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18451.48,
       (string) (len=4) "high": (float64) 18494.96,
       (string) (len=3) "low": (float64) 18382.65,
@@ -15013,7 +15013,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607563800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18434,
       (string) (len=4) "high": (float64) 18472.73,
       (string) (len=3) "low": (float64) 18320,
@@ -15025,7 +15025,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607565600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18421.62,
       (string) (len=4) "high": (float64) 18489.08,
       (string) (len=3) "low": (float64) 18414.32,
@@ -15037,7 +15037,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607567400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18385.11,
       (string) (len=4) "high": (float64) 18427.29,
       (string) (len=3) "low": (float64) 18352.04,
@@ -15049,7 +15049,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607569200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18435.33,
       (string) (len=4) "high": (float64) 18467.4,
       (string) (len=3) "low": (float64) 18352,
@@ -15061,7 +15061,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607571000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18410.62,
       (string) (len=4) "high": (float64) 18479.99,
       (string) (len=3) "low": (float64) 18394,
@@ -15073,7 +15073,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607572800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18464.44,
       (string) (len=4) "high": (float64) 18496.21,
       (string) (len=3) "low": (float64) 18390.02,
@@ -15085,7 +15085,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607574600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18419.25,
       (string) (len=4) "high": (float64) 18496.35,
       (string) (len=3) "low": (float64) 18396.6,
@@ -15097,7 +15097,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607576400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18359.22,
       (string) (len=4) "high": (float64) 18418.29,
       (string) (len=3) "low": (float64) 18356.62,
@@ -15109,7 +15109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607578200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18372.25,
       (string) (len=4) "high": (float64) 18399.91,
       (string) (len=3) "low": (float64) 18306.25,
@@ -15121,7 +15121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607580000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18299.79,
       (string) (len=4) "high": (float64) 18440.54,
       (string) (len=3) "low": (float64) 18290.48,
@@ -15133,7 +15133,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607581800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18303.7,
       (string) (len=4) "high": (float64) 18381.19,
       (string) (len=3) "low": (float64) 18292.7,
@@ -15145,7 +15145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607583600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18352.45,
       (string) (len=4) "high": (float64) 18386.58,
       (string) (len=3) "low": (float64) 18290.51,
@@ -15157,7 +15157,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607585400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18341.54,
       (string) (len=4) "high": (float64) 18391.35,
       (string) (len=3) "low": (float64) 18335.07,
@@ -15169,7 +15169,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607587200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18452.63,
       (string) (len=4) "high": (float64) 18470.59,
       (string) (len=3) "low": (float64) 18329.47,
@@ -15181,7 +15181,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607589000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18441.75,
       (string) (len=4) "high": (float64) 18460.49,
       (string) (len=3) "low": (float64) 18410.32,
@@ -15193,7 +15193,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607590800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18441.4,
       (string) (len=4) "high": (float64) 18447.92,
       (string) (len=3) "low": (float64) 18411.53,
@@ -15205,7 +15205,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607592600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18238.91,
       (string) (len=4) "high": (float64) 18480,
       (string) (len=3) "low": (float64) 18225.03,
@@ -15217,7 +15217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607594400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18195.18,
       (string) (len=4) "high": (float64) 18281.07,
       (string) (len=3) "low": (float64) 18155.2,
@@ -15229,7 +15229,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607596200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18139.24,
       (string) (len=4) "high": (float64) 18234.13,
       (string) (len=3) "low": (float64) 18118,
@@ -15241,7 +15241,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607598000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18145.21,
       (string) (len=4) "high": (float64) 18253.72,
       (string) (len=3) "low": (float64) 18119.63,
@@ -15253,7 +15253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607599800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18189.99,
       (string) (len=4) "high": (float64) 18232.14,
       (string) (len=3) "low": (float64) 18117.79,
@@ -15265,7 +15265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607601600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18241.78,
       (string) (len=4) "high": (float64) 18288.54,
       (string) (len=3) "low": (float64) 18168.51,
@@ -15277,7 +15277,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607603400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18205.02,
       (string) (len=4) "high": (float64) 18257.63,
       (string) (len=3) "low": (float64) 18180.68,
@@ -15289,7 +15289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607605200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18117.44,
       (string) (len=4) "high": (float64) 18203.86,
       (string) (len=3) "low": (float64) 18074.3,
@@ -15301,7 +15301,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607607000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18226.4,
       (string) (len=4) "high": (float64) 18238.85,
       (string) (len=3) "low": (float64) 18035.23,
@@ -15313,7 +15313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607608800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18055,
       (string) (len=4) "high": (float64) 18237.93,
       (string) (len=3) "low": (float64) 18045.02,
@@ -15325,7 +15325,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607610600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18071.95,
       (string) (len=4) "high": (float64) 18109.08,
       (string) (len=3) "low": (float64) 18031.13,
@@ -15337,7 +15337,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607612400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18014.83,
       (string) (len=4) "high": (float64) 18141.42,
       (string) (len=3) "low": (float64) 17905,
@@ -15349,7 +15349,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607614200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18130.99,
       (string) (len=4) "high": (float64) 18140.31,
       (string) (len=3) "low": (float64) 17960,
@@ -15361,7 +15361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607616000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18149.81,
       (string) (len=4) "high": (float64) 18196.37,
       (string) (len=3) "low": (float64) 18085,
@@ -15373,7 +15373,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607617800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18170.24,
       (string) (len=4) "high": (float64) 18222.04,
       (string) (len=3) "low": (float64) 18147.35,
@@ -15385,7 +15385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607619600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18089.86,
       (string) (len=4) "high": (float64) 18178.72,
       (string) (len=3) "low": (float64) 18069.01,
@@ -15397,7 +15397,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607621400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18206.01,
       (string) (len=4) "high": (float64) 18213.37,
       (string) (len=3) "low": (float64) 18078.25,
@@ -15409,7 +15409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607623200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18260.82,
       (string) (len=4) "high": (float64) 18268.14,
       (string) (len=3) "low": (float64) 18190,
@@ -15421,7 +15421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607625000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18270.84,
       (string) (len=4) "high": (float64) 18314.39,
       (string) (len=3) "low": (float64) 18245,
@@ -15433,7 +15433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607626800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18276.97,
       (string) (len=4) "high": (float64) 18315.02,
       (string) (len=3) "low": (float64) 18216.52,
@@ -15445,7 +15445,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607628600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18396.51,
       (string) (len=4) "high": (float64) 18400,
       (string) (len=3) "low": (float64) 18276.96,
@@ -15457,7 +15457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607630400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18412.69,
       (string) (len=4) "high": (float64) 18433.81,
       (string) (len=3) "low": (float64) 18365.48,
@@ -15469,7 +15469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607632200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18363.7,
       (string) (len=4) "high": (float64) 18412.69,
       (string) (len=3) "low": (float64) 18347.51,
@@ -15481,7 +15481,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607634000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18373.68,
       (string) (len=4) "high": (float64) 18410.5,
       (string) (len=3) "low": (float64) 18363.44,
@@ -15493,7 +15493,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607635800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18349.13,
       (string) (len=4) "high": (float64) 18387.19,
       (string) (len=3) "low": (float64) 18316.13,
@@ -15505,7 +15505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607637600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18340.37,
       (string) (len=4) "high": (float64) 18400,
       (string) (len=3) "low": (float64) 18255.01,
@@ -15517,7 +15517,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607639400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18328.24,
       (string) (len=4) "high": (float64) 18366.55,
       (string) (len=3) "low": (float64) 18255,
@@ -15529,7 +15529,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607641200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18341.8,
       (string) (len=4) "high": (float64) 18385,
       (string) (len=3) "low": (float64) 18324.15,
@@ -15541,7 +15541,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607643000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18253.44,
       (string) (len=4) "high": (float64) 18340.92,
       (string) (len=3) "low": (float64) 18228,
@@ -15553,7 +15553,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607644800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18112.67,
       (string) (len=4) "high": (float64) 18293.08,
       (string) (len=3) "low": (float64) 18087.99,
@@ -15565,7 +15565,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607646600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18011.41,
       (string) (len=4) "high": (float64) 18145.91,
       (string) (len=3) "low": (float64) 17940.73,
@@ -15577,7 +15577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607648400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17902.59,
       (string) (len=4) "high": (float64) 18083.73,
       (string) (len=3) "low": (float64) 17875.41,
@@ -15589,7 +15589,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607650200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17894.95,
       (string) (len=4) "high": (float64) 17988.56,
       (string) (len=3) "low": (float64) 17795.68,
@@ -15601,7 +15601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607652000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17987.85,
       (string) (len=4) "high": (float64) 18042.63,
       (string) (len=3) "low": (float64) 17850,
@@ -15613,7 +15613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607653800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17799.4,
       (string) (len=4) "high": (float64) 17996.68,
       (string) (len=3) "low": (float64) 17799.39,
@@ -15625,7 +15625,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607655600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17930.11,
       (string) (len=4) "high": (float64) 17941.16,
       (string) (len=3) "low": (float64) 17721.09,
@@ -15637,7 +15637,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607657400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17989.31,
       (string) (len=4) "high": (float64) 17994.34,
       (string) (len=3) "low": (float64) 17880,
@@ -15649,7 +15649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607659200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17966.5,
       (string) (len=4) "high": (float64) 18041.5,
       (string) (len=3) "low": (float64) 17930.72,
@@ -15661,7 +15661,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607661000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17959,
       (string) (len=4) "high": (float64) 17994.16,
       (string) (len=3) "low": (float64) 17917.7,
@@ -15673,7 +15673,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607662800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17907.05,
       (string) (len=4) "high": (float64) 18021.18,
       (string) (len=3) "low": (float64) 17875.23,
@@ -15685,7 +15685,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607664600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17893.77,
       (string) (len=4) "high": (float64) 17943.86,
       (string) (len=3) "low": (float64) 17831.92,
@@ -15697,7 +15697,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607666400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17842.7,
       (string) (len=4) "high": (float64) 17938.21,
       (string) (len=3) "low": (float64) 17839.01,
@@ -15709,7 +15709,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607668200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17921.54,
       (string) (len=4) "high": (float64) 17966.71,
       (string) (len=3) "low": (float64) 17816.49,
@@ -15721,7 +15721,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607670000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17791.26,
       (string) (len=4) "high": (float64) 17940.9,
       (string) (len=3) "low": (float64) 17763.14,
@@ -15733,7 +15733,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607671800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17800,
       (string) (len=4) "high": (float64) 17828.2,
       (string) (len=3) "low": (float64) 17691.1,
@@ -15745,7 +15745,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607673600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17942.05,
       (string) (len=4) "high": (float64) 17996,
       (string) (len=3) "low": (float64) 17800,
@@ -15757,7 +15757,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607675400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17886.29,
       (string) (len=4) "high": (float64) 17948.98,
       (string) (len=3) "low": (float64) 17816.28,
@@ -15769,7 +15769,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607677200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17826.38,
       (string) (len=4) "high": (float64) 17899.01,
       (string) (len=3) "low": (float64) 17777.79,
@@ -15781,7 +15781,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607679000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17799,
       (string) (len=4) "high": (float64) 17869.54,
       (string) (len=3) "low": (float64) 17720,
@@ -15793,7 +15793,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607680800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17801.31,
       (string) (len=4) "high": (float64) 17825,
       (string) (len=3) "low": (float64) 17580,
@@ -15805,7 +15805,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607682600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17741.9,
       (string) (len=4) "high": (float64) 17857.57,
       (string) (len=3) "low": (float64) 17708.02,
@@ -15817,7 +15817,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607684400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17642.04,
       (string) (len=4) "high": (float64) 17741.9,
       (string) (len=3) "low": (float64) 17613.63,
@@ -15829,7 +15829,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607686200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17639.93,
       (string) (len=4) "high": (float64) 17682.72,
       (string) (len=3) "low": (float64) 17581.65,
@@ -15841,7 +15841,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607688000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17794.07,
       (string) (len=4) "high": (float64) 17794.26,
       (string) (len=3) "low": (float64) 17611,
@@ -15853,7 +15853,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607689800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17860,
       (string) (len=4) "high": (float64) 17909.76,
       (string) (len=3) "low": (float64) 17784.58,
@@ -15865,7 +15865,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607691600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17863.49,
       (string) (len=4) "high": (float64) 17931.76,
       (string) (len=3) "low": (float64) 17826.81,
@@ -15877,7 +15877,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607693400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17970.13,
       (string) (len=4) "high": (float64) 17981.8,
       (string) (len=3) "low": (float64) 17800.19,
@@ -15889,7 +15889,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607695200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17971.78,
       (string) (len=4) "high": (float64) 18030.01,
       (string) (len=3) "low": (float64) 17942.48,
@@ -15901,7 +15901,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607697000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18059.6,
       (string) (len=4) "high": (float64) 18072.95,
       (string) (len=3) "low": (float64) 17900,
@@ -15913,7 +15913,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607698800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18060.91,
       (string) (len=4) "high": (float64) 18104.78,
       (string) (len=3) "low": (float64) 18038.23,
@@ -15925,7 +15925,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607700600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18107.72,
       (string) (len=4) "high": (float64) 18135,
       (string) (len=3) "low": (float64) 18028.6,
@@ -15937,7 +15937,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607702400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18003,
       (string) (len=4) "high": (float64) 18115.05,
       (string) (len=3) "low": (float64) 17988.93,
@@ -15949,7 +15949,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607704200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17976.88,
       (string) (len=4) "high": (float64) 18024.99,
       (string) (len=3) "low": (float64) 17943.48,
@@ -15961,7 +15961,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607706000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17922.69,
       (string) (len=4) "high": (float64) 18002.87,
       (string) (len=3) "low": (float64) 17875,
@@ -15973,7 +15973,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607707800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17986.22,
       (string) (len=4) "high": (float64) 18000,
       (string) (len=3) "low": (float64) 17859.95,
@@ -15985,7 +15985,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607709600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17961.46,
       (string) (len=4) "high": (float64) 18033.25,
       (string) (len=3) "low": (float64) 17938.34,
@@ -15997,7 +15997,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607711400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18042.9,
       (string) (len=4) "high": (float64) 18045.92,
       (string) (len=3) "low": (float64) 17960.24,
@@ -16009,7 +16009,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607713200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18062.04,
       (string) (len=4) "high": (float64) 18091,
       (string) (len=3) "low": (float64) 18025.99,
@@ -16021,7 +16021,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607715000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17970.96,
       (string) (len=4) "high": (float64) 18069.58,
       (string) (len=3) "low": (float64) 17960.09,
@@ -16033,7 +16033,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607716800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17952.86,
       (string) (len=4) "high": (float64) 18054.88,
       (string) (len=3) "low": (float64) 17911.51,
@@ -16045,7 +16045,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607718600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17976.34,
       (string) (len=4) "high": (float64) 17993.76,
       (string) (len=3) "low": (float64) 17941.02,
@@ -16057,7 +16057,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607720400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 17965.46,
       (string) (len=4) "high": (float64) 18030.99,
       (string) (len=3) "low": (float64) 17950.89,
@@ -16069,7 +16069,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607722200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18100.13,
       (string) (len=4) "high": (float64) 18125,
       (string) (len=3) "low": (float64) 17965.46,
@@ -16081,7 +16081,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607724000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18132.12,
       (string) (len=4) "high": (float64) 18181.61,
       (string) (len=3) "low": (float64) 18100.13,
@@ -16093,7 +16093,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607725800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18135,
       (string) (len=4) "high": (float64) 18155.23,
       (string) (len=3) "low": (float64) 18068.85,
@@ -16105,7 +16105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607727600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18074.71,
       (string) (len=4) "high": (float64) 18150,
       (string) (len=3) "low": (float64) 18037.92,
@@ -16117,7 +16117,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607729400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18042.15,
       (string) (len=4) "high": (float64) 18095.04,
       (string) (len=3) "low": (float64) 18025.95,
@@ -16129,7 +16129,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607731200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18289.02,
       (string) (len=4) "high": (float64) 18289.02,
       (string) (len=3) "low": (float64) 18023.57,
@@ -16141,7 +16141,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607733000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18344.07,
       (string) (len=4) "high": (float64) 18369,
       (string) (len=3) "low": (float64) 18217.18,
@@ -16153,7 +16153,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607734800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18312,
       (string) (len=4) "high": (float64) 18375,
       (string) (len=3) "low": (float64) 18276.96,
@@ -16165,7 +16165,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607736600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18300.44,
       (string) (len=4) "high": (float64) 18336.19,
       (string) (len=3) "low": (float64) 18284.87,
@@ -16177,7 +16177,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607738400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18322.04,
       (string) (len=4) "high": (float64) 18350,
       (string) (len=3) "low": (float64) 18291.5,
@@ -16189,7 +16189,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607740200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18323.39,
       (string) (len=4) "high": (float64) 18366.59,
       (string) (len=3) "low": (float64) 18306.79,
@@ -16201,7 +16201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607742000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18292.14,
       (string) (len=4) "high": (float64) 18328.82,
       (string) (len=3) "low": (float64) 18286.84,
@@ -16213,7 +16213,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607743800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18290.79,
       (string) (len=4) "high": (float64) 18345,
       (string) (len=3) "low": (float64) 18280,
@@ -16225,7 +16225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607745600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18289.75,
       (string) (len=4) "high": (float64) 18313.45,
       (string) (len=3) "low": (float64) 18265,
@@ -16237,7 +16237,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607747400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18375.17,
       (string) (len=4) "high": (float64) 18397.05,
       (string) (len=3) "low": (float64) 18289.74,
@@ -16249,7 +16249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607749200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18356.29,
       (string) (len=4) "high": (float64) 18399,
       (string) (len=3) "low": (float64) 18340.01,
@@ -16261,7 +16261,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607751000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18329.41,
       (string) (len=4) "high": (float64) 18366.64,
       (string) (len=3) "low": (float64) 18317.69,
@@ -16273,7 +16273,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607752800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18320.55,
       (string) (len=4) "high": (float64) 18372.75,
       (string) (len=3) "low": (float64) 18319.18,
@@ -16285,7 +16285,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607754600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18314.92,
       (string) (len=4) "high": (float64) 18320.6,
       (string) (len=3) "low": (float64) 18294.87,
@@ -16297,7 +16297,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607756400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18321.99,
       (string) (len=4) "high": (float64) 18357.51,
       (string) (len=3) "low": (float64) 18314.91,
@@ -16309,7 +16309,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607758200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18394.94,
       (string) (len=4) "high": (float64) 18414.7,
       (string) (len=3) "low": (float64) 18308.23,
@@ -16321,7 +16321,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607760000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18373.41,
       (string) (len=4) "high": (float64) 18460.28,
       (string) (len=3) "low": (float64) 18359.64,
@@ -16333,7 +16333,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607761800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18384.39,
       (string) (len=4) "high": (float64) 18400.8,
       (string) (len=3) "low": (float64) 18334.76,
@@ -16345,7 +16345,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607763600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18461.84,
       (string) (len=4) "high": (float64) 18477.77,
       (string) (len=3) "low": (float64) 18352.77,
@@ -16357,7 +16357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607765400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18434.01,
       (string) (len=4) "high": (float64) 18470.18,
       (string) (len=3) "low": (float64) 18401.2,
@@ -16369,7 +16369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607767200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18373.12,
       (string) (len=4) "high": (float64) 18459.6,
       (string) (len=3) "low": (float64) 18369.05,
@@ -16381,7 +16381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607769000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18383.65,
       (string) (len=4) "high": (float64) 18438.71,
       (string) (len=3) "low": (float64) 18373.12,
@@ -16393,7 +16393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607770800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18437.36,
       (string) (len=4) "high": (float64) 18453.19,
       (string) (len=3) "low": (float64) 18371.68,
@@ -16405,7 +16405,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607772600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18509.5,
       (string) (len=4) "high": (float64) 18518.24,
       (string) (len=3) "low": (float64) 18433.09,
@@ -16417,7 +16417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607774400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18471.79,
       (string) (len=4) "high": (float64) 18530.72,
       (string) (len=3) "low": (float64) 18461.36,
@@ -16429,7 +16429,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607776200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18447.23,
       (string) (len=4) "high": (float64) 18487.35,
       (string) (len=3) "low": (float64) 18427.56,
@@ -16441,7 +16441,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607778000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18440.59,
       (string) (len=4) "high": (float64) 18447.42,
       (string) (len=3) "low": (float64) 18386.18,
@@ -16453,7 +16453,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607779800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18405.01,
       (string) (len=4) "high": (float64) 18441.23,
       (string) (len=3) "low": (float64) 18401.49,
@@ -16465,7 +16465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607781600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18470,
       (string) (len=4) "high": (float64) 18477.99,
       (string) (len=3) "low": (float64) 18400,
@@ -16477,7 +16477,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607783400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18379.42,
       (string) (len=4) "high": (float64) 18470.01,
       (string) (len=3) "low": (float64) 18328.84,
@@ -16489,7 +16489,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607785200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18402.58,
       (string) (len=4) "high": (float64) 18411.81,
       (string) (len=3) "low": (float64) 18327.33,
@@ -16501,7 +16501,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607787000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18405.73,
       (string) (len=4) "high": (float64) 18448.52,
       (string) (len=3) "low": (float64) 18371.18,
@@ -16513,7 +16513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607788800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18433.34,
       (string) (len=4) "high": (float64) 18440.1,
       (string) (len=3) "low": (float64) 18367.12,
@@ -16525,7 +16525,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607790600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18406.28,
       (string) (len=4) "high": (float64) 18456.64,
       (string) (len=3) "low": (float64) 18388.71,
@@ -16537,7 +16537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607792400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18411.81,
       (string) (len=4) "high": (float64) 18429.43,
       (string) (len=3) "low": (float64) 18387.01,
@@ -16549,7 +16549,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607794200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18490.63,
       (string) (len=4) "high": (float64) 18519.38,
       (string) (len=3) "low": (float64) 18389.9,
@@ -16561,7 +16561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607796000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18706.78,
       (string) (len=4) "high": (float64) 18748.84,
       (string) (len=3) "low": (float64) 18490.31,
@@ -16573,7 +16573,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607797800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18699.08,
       (string) (len=4) "high": (float64) 18746.25,
       (string) (len=3) "low": (float64) 18689.21,
@@ -16585,7 +16585,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607799600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18821,
       (string) (len=4) "high": (float64) 18855.55,
       (string) (len=3) "low": (float64) 18699.08,
@@ -16597,7 +16597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607801400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18811.28,
       (string) (len=4) "high": (float64) 18844.12,
       (string) (len=3) "low": (float64) 18720,
@@ -16609,7 +16609,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607803200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18804.1,
       (string) (len=4) "high": (float64) 18844.43,
       (string) (len=3) "low": (float64) 18770,
@@ -16621,7 +16621,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607805000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18785.37,
       (string) (len=4) "high": (float64) 18855,
       (string) (len=3) "low": (float64) 18758,
@@ -16633,7 +16633,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607806800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18789.36,
       (string) (len=4) "high": (float64) 18842.82,
       (string) (len=3) "low": (float64) 18752,
@@ -16645,7 +16645,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607808600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18807.24,
       (string) (len=4) "high": (float64) 18849.95,
       (string) (len=3) "low": (float64) 18744,
@@ -16657,7 +16657,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607810400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18820.07,
       (string) (len=4) "high": (float64) 18835.87,
       (string) (len=3) "low": (float64) 18775.92,
@@ -16669,7 +16669,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607812200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18886.49,
       (string) (len=4) "high": (float64) 18955.34,
       (string) (len=3) "low": (float64) 18803.56,
@@ -16681,7 +16681,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607814000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18818.25,
       (string) (len=4) "high": (float64) 18895.13,
       (string) (len=3) "low": (float64) 18784.69,
@@ -16693,7 +16693,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607815800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18821.28,
       (string) (len=4) "high": (float64) 18841.17,
       (string) (len=3) "low": (float64) 18788.17,
@@ -16705,7 +16705,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607817600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18802.01,
       (string) (len=4) "high": (float64) 18880.28,
       (string) (len=3) "low": (float64) 18801.99,
@@ -16717,7 +16717,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607819400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18770.81,
       (string) (len=4) "high": (float64) 18812.92,
       (string) (len=3) "low": (float64) 18730,
@@ -16729,7 +16729,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607821200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18795.37,
       (string) (len=4) "high": (float64) 18810,
       (string) (len=3) "low": (float64) 18730,
@@ -16741,7 +16741,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607823000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18811.76,
       (string) (len=4) "high": (float64) 18820.33,
       (string) (len=3) "low": (float64) 18771.19,
@@ -16753,7 +16753,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607824800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18826.09,
       (string) (len=4) "high": (float64) 18827.32,
       (string) (len=3) "low": (float64) 18767.81,
@@ -16765,7 +16765,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607826600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18826.87,
       (string) (len=4) "high": (float64) 18849.38,
       (string) (len=3) "low": (float64) 18771.46,
@@ -16777,7 +16777,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607828400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18804.53,
       (string) (len=4) "high": (float64) 18845.12,
       (string) (len=3) "low": (float64) 18792.12,
@@ -16789,7 +16789,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607830200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18798.99,
       (string) (len=4) "high": (float64) 18804.53,
       (string) (len=3) "low": (float64) 18780.17,
@@ -16801,7 +16801,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607832000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18831.69,
       (string) (len=4) "high": (float64) 18843.52,
       (string) (len=3) "low": (float64) 18784.77,
@@ -16813,7 +16813,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607833800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18865,
       (string) (len=4) "high": (float64) 18894.63,
       (string) (len=3) "low": (float64) 18821.08,
@@ -16825,7 +16825,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607835600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18925.97,
       (string) (len=4) "high": (float64) 18926.29,
       (string) (len=3) "low": (float64) 18848.69,
@@ -16837,7 +16837,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607837400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18861.16,
       (string) (len=4) "high": (float64) 18949.99,
       (string) (len=3) "low": (float64) 18861.14,
@@ -16849,7 +16849,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607839200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18938.11,
       (string) (len=4) "high": (float64) 18942.44,
       (string) (len=3) "low": (float64) 18861.15,
@@ -16861,7 +16861,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607841000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18981.34,
       (string) (len=4) "high": (float64) 19000,
       (string) (len=3) "low": (float64) 18890.01,
@@ -16873,7 +16873,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607842800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19102.72,
       (string) (len=4) "high": (float64) 19153.45,
       (string) (len=3) "low": (float64) 18983.83,
@@ -16885,7 +16885,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607844600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19245.42,
       (string) (len=4) "high": (float64) 19290,
       (string) (len=3) "low": (float64) 19084.54,
@@ -16897,7 +16897,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607846400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19204.39,
       (string) (len=4) "high": (float64) 19305,
       (string) (len=3) "low": (float64) 19180.93,
@@ -16909,7 +16909,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607848200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19245.75,
       (string) (len=4) "high": (float64) 19256.89,
       (string) (len=3) "low": (float64) 19178.59,
@@ -16921,7 +16921,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607850000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19206,
       (string) (len=4) "high": (float64) 19255.97,
       (string) (len=3) "low": (float64) 19186.23,
@@ -16933,7 +16933,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607851800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19263.91,
       (string) (len=4) "high": (float64) 19304.99,
       (string) (len=3) "low": (float64) 19200.01,
@@ -16945,7 +16945,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607853600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19299.79,
       (string) (len=4) "high": (float64) 19365.13,
       (string) (len=3) "low": (float64) 19251.01,
@@ -16957,7 +16957,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607855400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19279.95,
       (string) (len=4) "high": (float64) 19349.13,
       (string) (len=3) "low": (float64) 19260.99,
@@ -16969,7 +16969,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607857200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19268.76,
       (string) (len=4) "high": (float64) 19296.07,
       (string) (len=3) "low": (float64) 19210.97,
@@ -16981,7 +16981,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607859000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19326.7,
       (string) (len=4) "high": (float64) 19349.36,
       (string) (len=3) "low": (float64) 19258.75,
@@ -16993,7 +16993,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607860800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19344.88,
       (string) (len=4) "high": (float64) 19388,
       (string) (len=3) "low": (float64) 19277.63,
@@ -17005,7 +17005,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607862600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19354.39,
       (string) (len=4) "high": (float64) 19410,
       (string) (len=3) "low": (float64) 19325.23,
@@ -17017,7 +17017,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607864400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19369.17,
       (string) (len=4) "high": (float64) 19421.03,
       (string) (len=3) "low": (float64) 19349.08,
@@ -17029,7 +17029,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607866200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19332.84,
       (string) (len=4) "high": (float64) 19369.17,
       (string) (len=3) "low": (float64) 19302.37,
@@ -17041,7 +17041,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607868000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19303.22,
       (string) (len=4) "high": (float64) 19368.62,
       (string) (len=3) "low": (float64) 19282.95,
@@ -17053,7 +17053,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607869800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19299.99,
       (string) (len=4) "high": (float64) 19314.14,
       (string) (len=3) "low": (float64) 19282.89,
@@ -17065,7 +17065,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607871600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19152.44,
       (string) (len=4) "high": (float64) 19339.97,
       (string) (len=3) "low": (float64) 19141.02,
@@ -17077,7 +17077,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607873400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19216.85,
       (string) (len=4) "high": (float64) 19220.61,
       (string) (len=3) "low": (float64) 19100,
@@ -17089,7 +17089,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607875200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19337.38,
       (string) (len=4) "high": (float64) 19386.15,
       (string) (len=3) "low": (float64) 19216.79,
@@ -17101,7 +17101,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607877000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19327.43,
       (string) (len=4) "high": (float64) 19372.79,
       (string) (len=3) "low": (float64) 19300.36,
@@ -17113,7 +17113,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607878800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19246.66,
       (string) (len=4) "high": (float64) 19334.99,
       (string) (len=3) "low": (float64) 19220.97,
@@ -17125,7 +17125,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607880600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19271.03,
       (string) (len=4) "high": (float64) 19273,
       (string) (len=3) "low": (float64) 19192.45,
@@ -17137,7 +17137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607882400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19205.8,
       (string) (len=4) "high": (float64) 19271.02,
       (string) (len=3) "low": (float64) 19169.75,
@@ -17149,7 +17149,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607884200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19178.48,
       (string) (len=4) "high": (float64) 19229.99,
       (string) (len=3) "low": (float64) 19167.63,
@@ -17161,7 +17161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607886000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19190.37,
       (string) (len=4) "high": (float64) 19200,
       (string) (len=3) "low": (float64) 19156.76,
@@ -17173,7 +17173,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607887800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19185.2,
       (string) (len=4) "high": (float64) 19219,
       (string) (len=3) "low": (float64) 19162,
@@ -17185,7 +17185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607889600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19115.01,
       (string) (len=4) "high": (float64) 19184.35,
       (string) (len=3) "low": (float64) 19115.01,
@@ -17197,7 +17197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607891400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19150,
       (string) (len=4) "high": (float64) 19169.49,
       (string) (len=3) "low": (float64) 19108,
@@ -17209,7 +17209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607893200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19188.25,
       (string) (len=4) "high": (float64) 19218.67,
       (string) (len=3) "low": (float64) 19141.53,
@@ -17221,7 +17221,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607895000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19181.85,
       (string) (len=4) "high": (float64) 19195.65,
       (string) (len=3) "low": (float64) 19165.1,
@@ -17233,7 +17233,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607896800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 18995.32,
       (string) (len=4) "high": (float64) 19185.56,
       (string) (len=3) "low": (float64) 18980,
@@ -17245,7 +17245,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607898600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19111.8,
       (string) (len=4) "high": (float64) 19121.79,
       (string) (len=3) "low": (float64) 18990.07,
@@ -17257,7 +17257,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607900400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19179.33,
       (string) (len=4) "high": (float64) 19217.62,
       (string) (len=3) "low": (float64) 19090,
@@ -17269,7 +17269,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607902200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19166.65,
       (string) (len=4) "high": (float64) 19183.41,
       (string) (len=3) "low": (float64) 19107.01,
@@ -17281,7 +17281,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607904000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19083.66,
       (string) (len=4) "high": (float64) 19166.65,
       (string) (len=3) "low": (float64) 19045.23,
@@ -17293,7 +17293,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607905800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19049.02,
       (string) (len=4) "high": (float64) 19105.09,
       (string) (len=3) "low": (float64) 18967.68,
@@ -17305,7 +17305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1607907600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 19093,
       (string) (len=4) "high": (float64) 19098.16,
       (string) (len=3) "low": (float64) 19008.36,

--- a/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()_custom_time_format
+++ b/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()_custom_time_format
@@ -1,7 +1,7 @@
 ([]observations.Observation) (len=77) {
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -9,7 +9,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1405524959,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
     Categories: (map[string]string) <nil>,
@@ -17,7 +17,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1574287726,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -25,7 +25,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1603529402,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
     Categories: (map[string]string) <nil>,
@@ -33,7 +33,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1595807633,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -41,7 +41,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1559557172,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -49,7 +49,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
     Categories: (map[string]string) <nil>,
@@ -57,7 +57,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1574287953,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -65,7 +65,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617849056,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -73,7 +73,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575221,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
     Categories: (map[string]string) <nil>,
@@ -81,7 +81,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -89,7 +89,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1550460496,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
     Categories: (map[string]string) <nil>,
@@ -97,7 +97,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1536626152,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -105,7 +105,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1552999318,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
     Categories: (map[string]string) <nil>,
@@ -113,7 +113,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -121,7 +121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1593692288,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
     Categories: (map[string]string) <nil>,
@@ -129,7 +129,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -137,7 +137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1567535861,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -145,7 +145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
     Categories: (map[string]string) <nil>,
@@ -153,7 +153,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -161,7 +161,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1559557172,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -169,7 +169,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
     Categories: (map[string]string) <nil>,
@@ -177,7 +177,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -185,7 +185,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1595807633,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
     Categories: (map[string]string) <nil>,
@@ -193,7 +193,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1372805194,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -201,7 +201,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1206658576,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
     Categories: (map[string]string) <nil>,
@@ -209,7 +209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -217,7 +217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1206658576,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -225,7 +225,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1223695126,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
     Categories: (map[string]string) <nil>,
@@ -233,7 +233,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -241,7 +241,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
     Categories: (map[string]string) <nil>,
@@ -249,7 +249,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1206670373,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -257,7 +257,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1385452011,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -265,7 +265,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575221,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
     Categories: (map[string]string) <nil>,
@@ -273,7 +273,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -281,7 +281,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -289,7 +289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
     Categories: (map[string]string) <nil>,
@@ -297,7 +297,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1550460496,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -305,7 +305,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1206670373,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
     Categories: (map[string]string) <nil>,
@@ -313,7 +313,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -321,7 +321,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1552999318,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
     Categories: (map[string]string) <nil>,
@@ -329,7 +329,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -337,7 +337,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1593692288,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
     Categories: (map[string]string) <nil>,
@@ -345,7 +345,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -353,7 +353,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1567535861,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -361,7 +361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
     Categories: (map[string]string) <nil>,
@@ -369,7 +369,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1337885580,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -377,7 +377,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1523637859,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -385,7 +385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
     Categories: (map[string]string) <nil>,
@@ -393,7 +393,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1491044460,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -401,7 +401,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402718467,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
     Categories: (map[string]string) <nil>,
@@ -409,7 +409,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954004,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -417,7 +417,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954139,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
     Categories: (map[string]string) <nil>,
@@ -425,7 +425,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609598,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -433,7 +433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609670,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
     Categories: (map[string]string) <nil>,
@@ -441,7 +441,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609742,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -449,7 +449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954098,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -457,7 +457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1406680213,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
     Categories: (map[string]string) <nil>,
@@ -465,7 +465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402718010,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -473,7 +473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1441273701,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -481,7 +481,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609579,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
     Categories: (map[string]string) <nil>,
@@ -489,7 +489,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609694,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -497,7 +497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1216128531,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
     Categories: (map[string]string) <nil>,
@@ -505,7 +505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609616,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -513,7 +513,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1500625053,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
     Categories: (map[string]string) <nil>,
@@ -521,7 +521,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954185,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -529,7 +529,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609683,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
     Categories: (map[string]string) <nil>,
@@ -537,7 +537,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954055,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -545,7 +545,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954161,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -553,7 +553,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1216128531,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
     Categories: (map[string]string) <nil>,
@@ -561,7 +561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1278097514,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
     Categories: (map[string]string) <nil>,
@@ -569,7 +569,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1216128531,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -577,7 +577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1502282628,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
     Categories: (map[string]string) <nil>,
@@ -585,7 +585,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609755,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
     Categories: (map[string]string) <nil>,
@@ -593,7 +593,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954076,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
     Categories: (map[string]string) <nil>,
@@ -601,7 +601,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609727,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
     Categories: (map[string]string) <nil>,
@@ -609,7 +609,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1243376609,
-    Data: (map[string]float64) (len=1) {
+    Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
     Categories: (map[string]string) <nil>,

--- a/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()_custom_time_format
+++ b/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()_custom_time_format
@@ -1,6 +1,7 @@
 ([]observations.Observation) (len=77) {
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -9,6 +10,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1405524959,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
@@ -17,6 +19,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1574287726,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -25,6 +28,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1603529402,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
@@ -33,6 +37,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1595807633,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -41,6 +46,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1559557172,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -49,6 +55,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
@@ -57,6 +64,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1574287953,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -65,6 +73,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617849056,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -73,6 +82,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575221,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
@@ -81,6 +91,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -89,6 +100,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1550460496,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
@@ -97,6 +109,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1536626152,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -105,6 +118,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1552999318,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
@@ -113,6 +127,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -121,6 +136,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1593692288,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
@@ -129,6 +145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -137,6 +154,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1567535861,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -145,6 +163,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
@@ -153,6 +172,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -161,6 +181,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1559557172,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -169,6 +190,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
@@ -177,6 +199,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -185,6 +208,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1595807633,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
@@ -193,6 +217,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1372805194,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -201,6 +226,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1206658576,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
@@ -209,6 +235,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -217,6 +244,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1206658576,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -225,6 +253,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1223695126,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
@@ -233,6 +262,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -241,6 +271,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
@@ -249,6 +280,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1206670373,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -257,6 +289,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1385452011,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -265,6 +298,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575221,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
@@ -273,6 +307,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -281,6 +316,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -289,6 +325,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
@@ -297,6 +334,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1550460496,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -305,6 +343,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1206670373,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
@@ -313,6 +352,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -321,6 +361,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1552999318,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
@@ -329,6 +370,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1197295014,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -337,6 +379,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1593692288,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
@@ -345,6 +388,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -353,6 +397,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1567535861,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -361,6 +406,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
@@ -369,6 +415,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1337885580,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -377,6 +424,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1523637859,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -385,6 +433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1547575074,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
@@ -393,6 +442,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1491044460,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -401,6 +451,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402718467,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
@@ -409,6 +460,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954004,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -417,6 +469,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954139,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
@@ -425,6 +478,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609598,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -433,6 +487,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609670,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
@@ -441,6 +496,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609742,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -449,6 +505,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954098,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -457,6 +514,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1406680213,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
@@ -465,6 +523,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402718010,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -473,6 +532,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1441273701,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -481,6 +541,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609579,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
@@ -489,6 +550,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609694,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -497,6 +559,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1216128531,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 5
     },
@@ -505,6 +568,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609616,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -513,6 +577,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1500625053,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
@@ -521,6 +586,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954185,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -529,6 +595,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609683,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },
@@ -537,6 +604,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954055,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -545,6 +613,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954161,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -553,6 +622,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1216128531,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 2.4
     },
@@ -561,6 +631,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1278097514,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 4
     },
@@ -569,6 +640,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1216128531,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -577,6 +649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1502282628,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 23
     },
@@ -585,6 +658,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609755,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 34
     },
@@ -593,6 +667,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402954076,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 54.46
     },
@@ -601,6 +676,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1402609727,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 3
     },
@@ -609,6 +685,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1243376609,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=1) {
       (string) (len=3) "val": (float64) 45
     },

--- a/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()_with_tags
+++ b/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()_with_tags
@@ -1,6 +1,7 @@
 ([]observations.Observation) (len=5) {
   (observations.Observation) {
     Time: (int64) 1605312000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16254.51,
       (string) (len=4) "high": (float64) 16339.6,
@@ -16,6 +17,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605313800,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16305,
       (string) (len=4) "high": (float64) 16305,
@@ -30,6 +32,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605315600,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16222.16,
       (string) (len=4) "high": (float64) 16303.88,
@@ -44,6 +47,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605317400,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16214.15,
       (string) (len=4) "high": (float64) 16246.92,
@@ -68,6 +72,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605319200,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16223.08,
       (string) (len=4) "high": (float64) 16234,

--- a/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()_with_tags
+++ b/test/assets/snapshots/dataprocessors/csv/TestCsv-GetObservations()_with_tags
@@ -1,7 +1,7 @@
 ([]observations.Observation) (len=5) {
   (observations.Observation) {
     Time: (int64) 1605312000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16254.51,
       (string) (len=4) "high": (float64) 16339.6,
       (string) (len=3) "low": (float64) 16240,
@@ -16,7 +16,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605313800,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16305,
       (string) (len=4) "high": (float64) 16305,
       (string) (len=3) "low": (float64) 16248.6,
@@ -30,7 +30,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605315600,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16222.16,
       (string) (len=4) "high": (float64) 16303.88,
       (string) (len=3) "low": (float64) 16210.99,
@@ -44,7 +44,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605317400,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16214.15,
       (string) (len=4) "high": (float64) 16246.92,
       (string) (len=3) "low": (float64) 16200.01,
@@ -68,7 +68,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1605319200,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=5) "close": (float64) 16223.08,
       (string) (len=4) "high": (float64) 16234,
       (string) (len=3) "low": (float64) 16175.62,

--- a/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()
+++ b/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()
@@ -1,6 +1,7 @@
 ([]observations.Observation) (len=43) {
   (observations.Observation) {
     Time: (int64) 1605312000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 806.42,
       (string) (len=6) "height": (float64) 29,
@@ -16,6 +17,7 @@
   },
   (observations.Observation) {
     Time: (int64) 84,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 85675.8,
       (string) (len=6) "height": (float64) 21,
@@ -92,6 +94,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1600121040,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 5723.42,
       (string) (len=6) "height": (float64) 6,
@@ -148,6 +151,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617019594,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 55280.07,
       (string) (len=6) "height": (float64) 77,
@@ -242,6 +246,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1608586764,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 50225.29,
       (string) (len=6) "height": (float64) 2,
@@ -352,6 +357,7 @@
   },
   (observations.Observation) {
     Time: (int64) 66,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 26877.51,
       (string) (len=6) "height": (float64) 97,
@@ -433,6 +439,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1608919478,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 52954.36,
       (string) (len=6) "height": (float64) 10,
@@ -516,6 +523,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1622287821,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 16632.15,
       (string) (len=6) "height": (float64) 61,
@@ -570,6 +578,7 @@
   },
   (observations.Observation) {
     Time: (int64) 85,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 13584.51,
       (string) (len=6) "height": (float64) 92,
@@ -584,6 +593,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1613308755,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 50471.87,
       (string) (len=6) "height": (float64) 36,
@@ -617,6 +627,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617219483,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 70472.85,
       (string) (len=6) "height": (float64) 60,
@@ -730,6 +741,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606432823,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 25040.01,
       (string) (len=6) "height": (float64) 31,
@@ -832,6 +844,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1614791060,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 47259.35,
       (string) (len=6) "height": (float64) 87,
@@ -878,6 +891,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1628881563,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 80035.82,
       (string) (len=6) "height": (float64) 29,
@@ -959,6 +973,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1630472273,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 50667.38,
       (string) (len=6) "height": (float64) 61,
@@ -1024,6 +1039,7 @@
   },
   (observations.Observation) {
     Time: (int64) 25,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 23992.36,
       (string) (len=6) "height": (float64) 48,
@@ -1078,6 +1094,7 @@
   },
   (observations.Observation) {
     Time: (int64) 61,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 81098,
       (string) (len=6) "height": (float64) 61,
@@ -1120,6 +1137,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1624576649,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 34419.52,
       (string) (len=6) "height": (float64) 43,
@@ -1134,6 +1152,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1621042973,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 3733.87,
       (string) (len=6) "height": (float64) 23,
@@ -1228,6 +1247,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1627955069,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 55083.37,
       (string) (len=6) "height": (float64) 53,
@@ -1302,6 +1322,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1623755608,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 78734.04,
       (string) (len=6) "height": (float64) 59,
@@ -1333,6 +1354,7 @@
   },
   (observations.Observation) {
     Time: (int64) 9,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 65074.17,
       (string) (len=6) "height": (float64) 84,
@@ -1385,6 +1407,7 @@
   },
   (observations.Observation) {
     Time: (int64) 74,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 68838.07,
       (string) (len=6) "height": (float64) 99,
@@ -1449,6 +1472,7 @@
   },
   (observations.Observation) {
     Time: (int64) 40,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 26536,
       (string) (len=6) "height": (float64) 98,
@@ -1473,6 +1497,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1613525487,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 7445.69,
       (string) (len=6) "height": (float64) 28,
@@ -1490,6 +1515,7 @@
   },
   (observations.Observation) {
     Time: (int64) 64,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 48618.44,
       (string) (len=6) "height": (float64) 25,
@@ -1597,6 +1623,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604120604,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 15287.28,
       (string) (len=6) "height": (float64) 6,
@@ -1673,6 +1700,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604097627,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 50759.42,
       (string) (len=6) "height": (float64) 97,
@@ -1735,6 +1763,7 @@
   },
   (observations.Observation) {
     Time: (int64) 5,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 97957.4,
       (string) (len=6) "height": (float64) 55,
@@ -1806,6 +1835,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1623223829,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 64219.03,
       (string) (len=6) "height": (float64) 99,
@@ -1900,6 +1930,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604622073,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 94929.32,
       (string) (len=6) "height": (float64) 47,
@@ -1981,6 +2012,7 @@
   },
   (observations.Observation) {
     Time: (int64) 2,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 49371.19,
       (string) (len=6) "height": (float64) 9,
@@ -2084,6 +2116,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1612730263,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 29806.52,
       (string) (len=6) "height": (float64) 28,
@@ -2154,6 +2187,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1631022711,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 49727.06,
       (string) (len=6) "height": (float64) 37,
@@ -2192,6 +2226,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1619646514,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 66531.98,
       (string) (len=6) "height": (float64) 89,
@@ -2232,6 +2267,7 @@
   },
   (observations.Observation) {
     Time: (int64) 65,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 55207.77,
       (string) (len=6) "height": (float64) 91,
@@ -2336,6 +2372,7 @@
   },
   (observations.Observation) {
     Time: (int64) 9,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 67160.35,
       (string) (len=6) "height": (float64) 56,
@@ -2428,6 +2465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 41,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 48022.74,
       (string) (len=6) "height": (float64) 55,
@@ -2457,6 +2495,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1610495569,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 77100.18,
       (string) (len=6) "height": (float64) 23,
@@ -2561,6 +2600,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1603538489,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 57391.29,
       (string) (len=6) "height": (float64) 7,
@@ -2606,6 +2646,7 @@
   },
   (observations.Observation) {
     Time: (int64) 27,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 10663.97,
       (string) (len=6) "height": (float64) 99,
@@ -2690,6 +2731,7 @@
   },
   (observations.Observation) {
     Time: (int64) 67,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 80336.6,
       (string) (len=6) "height": (float64) 5,
@@ -2743,6 +2785,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1631499271,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 21052.59,
       (string) (len=6) "height": (float64) 81,

--- a/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()
+++ b/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()
@@ -1,7 +1,7 @@
 ([]observations.Observation) (len=43) {
   (observations.Observation) {
     Time: (int64) 1605312000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 806.42,
       (string) (len=6) "height": (float64) 29,
       (string) (len=6) "rating": (float64) 86,
@@ -16,7 +16,7 @@
   },
   (observations.Observation) {
     Time: (int64) 84,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 85675.8,
       (string) (len=6) "height": (float64) 21,
       (string) (len=6) "rating": (float64) 66,
@@ -92,7 +92,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1600121040,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 5723.42,
       (string) (len=6) "height": (float64) 6,
       (string) (len=6) "rating": (float64) 22,
@@ -148,7 +148,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617019594,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 55280.07,
       (string) (len=6) "height": (float64) 77,
       (string) (len=6) "rating": (float64) 54,
@@ -242,7 +242,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1608586764,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 50225.29,
       (string) (len=6) "height": (float64) 2,
       (string) (len=6) "rating": (float64) 31,
@@ -352,7 +352,7 @@
   },
   (observations.Observation) {
     Time: (int64) 66,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 26877.51,
       (string) (len=6) "height": (float64) 97,
       (string) (len=6) "rating": (float64) 60,
@@ -433,7 +433,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1608919478,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 52954.36,
       (string) (len=6) "height": (float64) 10,
       (string) (len=6) "rating": (float64) 18,
@@ -516,7 +516,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1622287821,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 16632.15,
       (string) (len=6) "height": (float64) 61,
       (string) (len=6) "rating": (float64) 39,
@@ -570,7 +570,7 @@
   },
   (observations.Observation) {
     Time: (int64) 85,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 13584.51,
       (string) (len=6) "height": (float64) 92,
       (string) (len=6) "rating": (float64) 50,
@@ -584,7 +584,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1613308755,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 50471.87,
       (string) (len=6) "height": (float64) 36,
       (string) (len=6) "rating": (float64) 58,
@@ -617,7 +617,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617219483,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 70472.85,
       (string) (len=6) "height": (float64) 60,
       (string) (len=6) "rating": (float64) 6,
@@ -730,7 +730,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606432823,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 25040.01,
       (string) (len=6) "height": (float64) 31,
       (string) (len=6) "rating": (float64) 0,
@@ -832,7 +832,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1614791060,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 47259.35,
       (string) (len=6) "height": (float64) 87,
       (string) (len=6) "rating": (float64) 53,
@@ -878,7 +878,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1628881563,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 80035.82,
       (string) (len=6) "height": (float64) 29,
       (string) (len=6) "rating": (float64) 91,
@@ -959,7 +959,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1630472273,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 50667.38,
       (string) (len=6) "height": (float64) 61,
       (string) (len=6) "rating": (float64) 6,
@@ -1024,7 +1024,7 @@
   },
   (observations.Observation) {
     Time: (int64) 25,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 23992.36,
       (string) (len=6) "height": (float64) 48,
       (string) (len=6) "rating": (float64) 6,
@@ -1078,7 +1078,7 @@
   },
   (observations.Observation) {
     Time: (int64) 61,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 81098,
       (string) (len=6) "height": (float64) 61,
       (string) (len=6) "rating": (float64) 73,
@@ -1120,7 +1120,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1624576649,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 34419.52,
       (string) (len=6) "height": (float64) 43,
       (string) (len=6) "rating": (float64) 70,
@@ -1134,7 +1134,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1621042973,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 3733.87,
       (string) (len=6) "height": (float64) 23,
       (string) (len=6) "rating": (float64) 18,
@@ -1228,7 +1228,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1627955069,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 55083.37,
       (string) (len=6) "height": (float64) 53,
       (string) (len=6) "rating": (float64) 90,
@@ -1302,7 +1302,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1623755608,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 78734.04,
       (string) (len=6) "height": (float64) 59,
       (string) (len=6) "rating": (float64) 31,
@@ -1333,7 +1333,7 @@
   },
   (observations.Observation) {
     Time: (int64) 9,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 65074.17,
       (string) (len=6) "height": (float64) 84,
       (string) (len=6) "rating": (float64) 89,
@@ -1385,7 +1385,7 @@
   },
   (observations.Observation) {
     Time: (int64) 74,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 68838.07,
       (string) (len=6) "height": (float64) 99,
       (string) (len=6) "rating": (float64) 7,
@@ -1449,7 +1449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 40,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 26536,
       (string) (len=6) "height": (float64) 98,
       (string) (len=6) "rating": (float64) 22,
@@ -1473,7 +1473,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1613525487,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 7445.69,
       (string) (len=6) "height": (float64) 28,
       (string) (len=6) "rating": (float64) 16,
@@ -1490,7 +1490,7 @@
   },
   (observations.Observation) {
     Time: (int64) 64,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 48618.44,
       (string) (len=6) "height": (float64) 25,
       (string) (len=6) "rating": (float64) 90,
@@ -1597,7 +1597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604120604,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 15287.28,
       (string) (len=6) "height": (float64) 6,
       (string) (len=6) "rating": (float64) 71,
@@ -1673,7 +1673,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604097627,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 50759.42,
       (string) (len=6) "height": (float64) 97,
       (string) (len=6) "rating": (float64) 49,
@@ -1735,7 +1735,7 @@
   },
   (observations.Observation) {
     Time: (int64) 5,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 97957.4,
       (string) (len=6) "height": (float64) 55,
       (string) (len=6) "rating": (float64) 32,
@@ -1806,7 +1806,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1623223829,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 64219.03,
       (string) (len=6) "height": (float64) 99,
       (string) (len=6) "rating": (float64) 81,
@@ -1900,7 +1900,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604622073,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 94929.32,
       (string) (len=6) "height": (float64) 47,
       (string) (len=6) "rating": (float64) 1,
@@ -1981,7 +1981,7 @@
   },
   (observations.Observation) {
     Time: (int64) 2,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 49371.19,
       (string) (len=6) "height": (float64) 9,
       (string) (len=6) "rating": (float64) 28,
@@ -2084,7 +2084,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1612730263,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 29806.52,
       (string) (len=6) "height": (float64) 28,
       (string) (len=6) "rating": (float64) 55,
@@ -2154,7 +2154,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1631022711,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 49727.06,
       (string) (len=6) "height": (float64) 37,
       (string) (len=6) "rating": (float64) 33,
@@ -2192,7 +2192,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1619646514,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 66531.98,
       (string) (len=6) "height": (float64) 89,
       (string) (len=6) "rating": (float64) 83,
@@ -2232,7 +2232,7 @@
   },
   (observations.Observation) {
     Time: (int64) 65,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 55207.77,
       (string) (len=6) "height": (float64) 91,
       (string) (len=6) "rating": (float64) 53,
@@ -2336,7 +2336,7 @@
   },
   (observations.Observation) {
     Time: (int64) 9,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 67160.35,
       (string) (len=6) "height": (float64) 56,
       (string) (len=6) "rating": (float64) 19,
@@ -2428,7 +2428,7 @@
   },
   (observations.Observation) {
     Time: (int64) 41,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 48022.74,
       (string) (len=6) "height": (float64) 55,
       (string) (len=6) "rating": (float64) 26,
@@ -2457,7 +2457,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1610495569,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 77100.18,
       (string) (len=6) "height": (float64) 23,
       (string) (len=6) "rating": (float64) 29,
@@ -2561,7 +2561,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1603538489,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 57391.29,
       (string) (len=6) "height": (float64) 7,
       (string) (len=6) "rating": (float64) 64,
@@ -2606,7 +2606,7 @@
   },
   (observations.Observation) {
     Time: (int64) 27,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 10663.97,
       (string) (len=6) "height": (float64) 99,
       (string) (len=6) "rating": (float64) 23,
@@ -2690,7 +2690,7 @@
   },
   (observations.Observation) {
     Time: (int64) 67,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 80336.6,
       (string) (len=6) "height": (float64) 5,
       (string) (len=6) "rating": (float64) 96,
@@ -2743,7 +2743,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1631499271,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 21052.59,
       (string) (len=6) "height": (float64) 81,
       (string) (len=6) "rating": (float64) 4,

--- a/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()_--_with_a_string_value_for_some_data_points
+++ b/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()_--_with_a_string_value_for_some_data_points
@@ -1,7 +1,7 @@
 ([]observations.Observation) (len=1) {
   (observations.Observation) {
     Time: (int64) 1605312000,
-    Data: (map[string]float64) (len=5) {
+    Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 806.42,
       (string) (len=6) "height": (float64) 29,
       (string) (len=6) "rating": (float64) 86,

--- a/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()_--_with_a_string_value_for_some_data_points
+++ b/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()_--_with_a_string_value_for_some_data_points
@@ -1,6 +1,7 @@
 ([]observations.Observation) (len=1) {
   (observations.Observation) {
     Time: (int64) 1605312000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=5) {
       (string) (len=7) "eventId": (float64) 806.42,
       (string) (len=6) "height": (float64) 29,

--- a/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()_--_with_selected_measurements
+++ b/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()_--_with_selected_measurements
@@ -1,6 +1,7 @@
 ([]observations.Observation) (len=43) {
   (observations.Observation) {
     Time: (int64) 1605312000,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 806.42,
       (string) (len=6) "rating": (float64) 86,
@@ -14,6 +15,7 @@
   },
   (observations.Observation) {
     Time: (int64) 84,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 85675.8,
       (string) (len=6) "rating": (float64) 66,
@@ -88,6 +90,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1600121040,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 5723.42,
       (string) (len=6) "rating": (float64) 22,
@@ -142,6 +145,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617019594,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 55280.07,
       (string) (len=6) "rating": (float64) 54,
@@ -234,6 +238,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1608586764,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 50225.29,
       (string) (len=6) "rating": (float64) 31,
@@ -342,6 +347,7 @@
   },
   (observations.Observation) {
     Time: (int64) 66,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 26877.51,
       (string) (len=6) "rating": (float64) 60,
@@ -421,6 +427,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1608919478,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 52954.36,
       (string) (len=6) "rating": (float64) 18,
@@ -502,6 +509,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1622287821,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 16632.15,
       (string) (len=6) "rating": (float64) 39,
@@ -554,6 +562,7 @@
   },
   (observations.Observation) {
     Time: (int64) 85,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 13584.51,
       (string) (len=6) "rating": (float64) 50,
@@ -566,6 +575,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1613308755,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 50471.87,
       (string) (len=6) "rating": (float64) 58,
@@ -597,6 +607,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617219483,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 70472.85,
       (string) (len=6) "rating": (float64) 6,
@@ -708,6 +719,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606432823,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 25040.01,
       (string) (len=6) "rating": (float64) 0,
@@ -808,6 +820,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1614791060,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 47259.35,
       (string) (len=6) "rating": (float64) 53,
@@ -852,6 +865,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1628881563,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 80035.82,
       (string) (len=6) "rating": (float64) 91,
@@ -931,6 +945,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1630472273,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 50667.38,
       (string) (len=6) "rating": (float64) 6,
@@ -994,6 +1009,7 @@
   },
   (observations.Observation) {
     Time: (int64) 25,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 23992.36,
       (string) (len=6) "rating": (float64) 6,
@@ -1046,6 +1062,7 @@
   },
   (observations.Observation) {
     Time: (int64) 61,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 81098,
       (string) (len=6) "rating": (float64) 73,
@@ -1086,6 +1103,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1624576649,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 34419.52,
       (string) (len=6) "rating": (float64) 70,
@@ -1098,6 +1116,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1621042973,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 3733.87,
       (string) (len=6) "rating": (float64) 18,
@@ -1190,6 +1209,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1627955069,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 55083.37,
       (string) (len=6) "rating": (float64) 90,
@@ -1262,6 +1282,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1623755608,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 78734.04,
       (string) (len=6) "rating": (float64) 31,
@@ -1291,6 +1312,7 @@
   },
   (observations.Observation) {
     Time: (int64) 9,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 65074.17,
       (string) (len=6) "rating": (float64) 89,
@@ -1341,6 +1363,7 @@
   },
   (observations.Observation) {
     Time: (int64) 74,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 68838.07,
       (string) (len=6) "rating": (float64) 7,
@@ -1403,6 +1426,7 @@
   },
   (observations.Observation) {
     Time: (int64) 40,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 26536,
       (string) (len=6) "rating": (float64) 22,
@@ -1425,6 +1449,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1613525487,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 7445.69,
       (string) (len=6) "rating": (float64) 16,
@@ -1440,6 +1465,7 @@
   },
   (observations.Observation) {
     Time: (int64) 64,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 48618.44,
       (string) (len=6) "rating": (float64) 90,
@@ -1545,6 +1571,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604120604,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 15287.28,
       (string) (len=6) "rating": (float64) 71,
@@ -1619,6 +1646,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604097627,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 50759.42,
       (string) (len=6) "rating": (float64) 49,
@@ -1679,6 +1707,7 @@
   },
   (observations.Observation) {
     Time: (int64) 5,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 97957.4,
       (string) (len=6) "rating": (float64) 32,
@@ -1748,6 +1777,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1623223829,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 64219.03,
       (string) (len=6) "rating": (float64) 81,
@@ -1840,6 +1870,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604622073,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 94929.32,
       (string) (len=6) "rating": (float64) 1,
@@ -1919,6 +1950,7 @@
   },
   (observations.Observation) {
     Time: (int64) 2,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 49371.19,
       (string) (len=6) "rating": (float64) 28,
@@ -2020,6 +2052,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1612730263,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 29806.52,
       (string) (len=6) "rating": (float64) 55,
@@ -2088,6 +2121,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1631022711,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 49727.06,
       (string) (len=6) "rating": (float64) 33,
@@ -2124,6 +2158,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1619646514,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 66531.98,
       (string) (len=6) "rating": (float64) 83,
@@ -2162,6 +2197,7 @@
   },
   (observations.Observation) {
     Time: (int64) 65,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 55207.77,
       (string) (len=6) "rating": (float64) 53,
@@ -2264,6 +2300,7 @@
   },
   (observations.Observation) {
     Time: (int64) 9,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 67160.35,
       (string) (len=6) "rating": (float64) 19,
@@ -2354,6 +2391,7 @@
   },
   (observations.Observation) {
     Time: (int64) 41,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 48022.74,
       (string) (len=6) "rating": (float64) 26,
@@ -2381,6 +2419,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1610495569,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 77100.18,
       (string) (len=6) "rating": (float64) 29,
@@ -2483,6 +2522,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1603538489,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 57391.29,
       (string) (len=6) "rating": (float64) 64,
@@ -2526,6 +2566,7 @@
   },
   (observations.Observation) {
     Time: (int64) 27,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 10663.97,
       (string) (len=6) "rating": (float64) 23,
@@ -2608,6 +2649,7 @@
   },
   (observations.Observation) {
     Time: (int64) 67,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 80336.6,
       (string) (len=6) "rating": (float64) 96,
@@ -2659,6 +2701,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1631499271,
+    Data: (map[string]float64) <nil>,
     Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 21052.59,
       (string) (len=6) "rating": (float64) 4,

--- a/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()_--_with_selected_measurements
+++ b/test/assets/snapshots/dataprocessors/json/TestJson-GetObservations()_--_with_selected_measurements
@@ -1,7 +1,7 @@
 ([]observations.Observation) (len=43) {
   (observations.Observation) {
     Time: (int64) 1605312000,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 806.42,
       (string) (len=6) "rating": (float64) 86,
       (string) (len=6) "target": (float64) 42
@@ -14,7 +14,7 @@
   },
   (observations.Observation) {
     Time: (int64) 84,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 85675.8,
       (string) (len=6) "rating": (float64) 66,
       (string) (len=6) "target": (float64) 80
@@ -88,7 +88,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1600121040,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 5723.42,
       (string) (len=6) "rating": (float64) 22,
       (string) (len=6) "target": (float64) 8
@@ -142,7 +142,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617019594,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 55280.07,
       (string) (len=6) "rating": (float64) 54,
       (string) (len=6) "target": (float64) 49
@@ -234,7 +234,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1608586764,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 50225.29,
       (string) (len=6) "rating": (float64) 31,
       (string) (len=6) "target": (float64) 20
@@ -342,7 +342,7 @@
   },
   (observations.Observation) {
     Time: (int64) 66,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 26877.51,
       (string) (len=6) "rating": (float64) 60,
       (string) (len=6) "target": (float64) 71
@@ -421,7 +421,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1608919478,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 52954.36,
       (string) (len=6) "rating": (float64) 18,
       (string) (len=6) "target": (float64) 49
@@ -502,7 +502,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1622287821,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 16632.15,
       (string) (len=6) "rating": (float64) 39,
       (string) (len=6) "target": (float64) 46
@@ -554,7 +554,7 @@
   },
   (observations.Observation) {
     Time: (int64) 85,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 13584.51,
       (string) (len=6) "rating": (float64) 50,
       (string) (len=6) "target": (float64) 100
@@ -566,7 +566,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1613308755,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 50471.87,
       (string) (len=6) "rating": (float64) 58,
       (string) (len=6) "target": (float64) 59
@@ -597,7 +597,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1617219483,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 70472.85,
       (string) (len=6) "rating": (float64) 6,
       (string) (len=6) "target": (float64) 74
@@ -708,7 +708,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1606432823,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 25040.01,
       (string) (len=6) "rating": (float64) 0,
       (string) (len=6) "target": (float64) 76
@@ -808,7 +808,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1614791060,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 47259.35,
       (string) (len=6) "rating": (float64) 53,
       (string) (len=6) "target": (float64) 89
@@ -852,7 +852,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1628881563,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 80035.82,
       (string) (len=6) "rating": (float64) 91,
       (string) (len=6) "target": (float64) 48
@@ -931,7 +931,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1630472273,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 50667.38,
       (string) (len=6) "rating": (float64) 6,
       (string) (len=6) "target": (float64) 73
@@ -994,7 +994,7 @@
   },
   (observations.Observation) {
     Time: (int64) 25,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 23992.36,
       (string) (len=6) "rating": (float64) 6,
       (string) (len=6) "target": (float64) 4
@@ -1046,7 +1046,7 @@
   },
   (observations.Observation) {
     Time: (int64) 61,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 81098,
       (string) (len=6) "rating": (float64) 73,
       (string) (len=6) "target": (float64) 16
@@ -1086,7 +1086,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1624576649,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 34419.52,
       (string) (len=6) "rating": (float64) 70,
       (string) (len=6) "target": (float64) 11
@@ -1098,7 +1098,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1621042973,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 3733.87,
       (string) (len=6) "rating": (float64) 18,
       (string) (len=6) "target": (float64) 38
@@ -1190,7 +1190,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1627955069,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 55083.37,
       (string) (len=6) "rating": (float64) 90,
       (string) (len=6) "target": (float64) 52
@@ -1262,7 +1262,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1623755608,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 78734.04,
       (string) (len=6) "rating": (float64) 31,
       (string) (len=6) "target": (float64) 71
@@ -1291,7 +1291,7 @@
   },
   (observations.Observation) {
     Time: (int64) 9,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 65074.17,
       (string) (len=6) "rating": (float64) 89,
       (string) (len=6) "target": (float64) 90
@@ -1341,7 +1341,7 @@
   },
   (observations.Observation) {
     Time: (int64) 74,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 68838.07,
       (string) (len=6) "rating": (float64) 7,
       (string) (len=6) "target": (float64) 96
@@ -1403,7 +1403,7 @@
   },
   (observations.Observation) {
     Time: (int64) 40,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 26536,
       (string) (len=6) "rating": (float64) 22,
       (string) (len=6) "target": (float64) 59
@@ -1425,7 +1425,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1613525487,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 7445.69,
       (string) (len=6) "rating": (float64) 16,
       (string) (len=6) "target": (float64) 53
@@ -1440,7 +1440,7 @@
   },
   (observations.Observation) {
     Time: (int64) 64,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 48618.44,
       (string) (len=6) "rating": (float64) 90,
       (string) (len=6) "target": (float64) 69
@@ -1545,7 +1545,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604120604,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 15287.28,
       (string) (len=6) "rating": (float64) 71,
       (string) (len=6) "target": (float64) 34
@@ -1619,7 +1619,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604097627,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 50759.42,
       (string) (len=6) "rating": (float64) 49,
       (string) (len=6) "target": (float64) 14
@@ -1679,7 +1679,7 @@
   },
   (observations.Observation) {
     Time: (int64) 5,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 97957.4,
       (string) (len=6) "rating": (float64) 32,
       (string) (len=6) "target": (float64) 95
@@ -1748,7 +1748,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1623223829,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 64219.03,
       (string) (len=6) "rating": (float64) 81,
       (string) (len=6) "target": (float64) 8
@@ -1840,7 +1840,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1604622073,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 94929.32,
       (string) (len=6) "rating": (float64) 1,
       (string) (len=6) "target": (float64) 48
@@ -1919,7 +1919,7 @@
   },
   (observations.Observation) {
     Time: (int64) 2,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 49371.19,
       (string) (len=6) "rating": (float64) 28,
       (string) (len=6) "target": (float64) 44
@@ -2020,7 +2020,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1612730263,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 29806.52,
       (string) (len=6) "rating": (float64) 55,
       (string) (len=6) "target": (float64) 38
@@ -2088,7 +2088,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1631022711,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 49727.06,
       (string) (len=6) "rating": (float64) 33,
       (string) (len=6) "target": (float64) 79
@@ -2124,7 +2124,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1619646514,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 66531.98,
       (string) (len=6) "rating": (float64) 83,
       (string) (len=6) "target": (float64) 82
@@ -2162,7 +2162,7 @@
   },
   (observations.Observation) {
     Time: (int64) 65,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 55207.77,
       (string) (len=6) "rating": (float64) 53,
       (string) (len=6) "target": (float64) 16
@@ -2264,7 +2264,7 @@
   },
   (observations.Observation) {
     Time: (int64) 9,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 67160.35,
       (string) (len=6) "rating": (float64) 19,
       (string) (len=6) "target": (float64) 87
@@ -2354,7 +2354,7 @@
   },
   (observations.Observation) {
     Time: (int64) 41,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 48022.74,
       (string) (len=6) "rating": (float64) 26,
       (string) (len=6) "target": (float64) 77
@@ -2381,7 +2381,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1610495569,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 77100.18,
       (string) (len=6) "rating": (float64) 29,
       (string) (len=6) "target": (float64) 42
@@ -2483,7 +2483,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1603538489,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 57391.29,
       (string) (len=6) "rating": (float64) 64,
       (string) (len=6) "target": (float64) 81
@@ -2526,7 +2526,7 @@
   },
   (observations.Observation) {
     Time: (int64) 27,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 10663.97,
       (string) (len=6) "rating": (float64) 23,
       (string) (len=6) "target": (float64) 98
@@ -2608,7 +2608,7 @@
   },
   (observations.Observation) {
     Time: (int64) 67,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 80336.6,
       (string) (len=6) "rating": (float64) 96,
       (string) (len=6) "target": (float64) 35
@@ -2659,7 +2659,7 @@
   },
   (observations.Observation) {
     Time: (int64) 1631499271,
-    Data: (map[string]float64) (len=3) {
+    Measurements: (map[string]float64) (len=3) {
       (string) (len=7) "eventId": (float64) 21052.59,
       (string) (len=6) "rating": (float64) 4,
       (string) (len=6) "target": (float64) 12


### PR DESCRIPTION
To get around the catch-22 of updating the observation struct interface, I pushed a branch in spiceai with a change to have both Measurements and Data. This PR updates the spiceai dependency to point to that branch and sends it over using Measurements.

The next steps are to update spiceai to reference this version of the data-components-contrib. Then update data-components-contrib again to point to the latest spiceai.